### PR TITLE
Fix: Missing linux application_stack input vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1270,6 +1270,11 @@ object({
       node_version                = optional(string)
       powershell_core_version     = optional(string)
       python_version              = optional(string)
+      go_version                  = optional(string)
+      ruby_version                = optional(string)
+      java_server                 = optional(string)
+      java_server_version         = optional(string)
+      php_version                 = optional(string)
       use_custom_runtime          = optional(bool)
       use_dotnet_isolated_runtime = optional(bool)
       docker = optional(list(object({

--- a/README.md
+++ b/README.md
@@ -1182,6 +1182,11 @@ Description:   An object that configures the Function App's `site_config` block.
  - `node_version` - (Optional) The version of Node to run. Possible values include `12`, `14`, `16` and `18`.
  - `powershell_core_version` - (Optional) The version of PowerShell Core to run. Possible values are `7`, and `7.2`.
  - `python_version` - (Optional) The version of Python to run. Possible values are `3.12`, `3.11`, `3.10`, `3.9`, `3.8` and `3.7`.
+ - `go_version` - (Optional) The version of Go to use. Possible values are `1.18`, and `1.19`.
+ - `ruby_version` - (Optional) The version of Ruby to use. Possible values are `2.6`, and `2.7`.
+ - `java_server` - (Optional) The Java server type. Possible values are `JAVA`, `TOMCAT`, and `JBOSSEAP`.
+ - `java_server_version` - (Optional) The version of the Java server to use.
+ - `php_version` - (Optional) The version of PHP to use. Possible values are `7.4`, `8.0`, `8.1`, and `8.2`.
  - `use_custom_runtime` - (Optional) Should the Linux Function App use a custom runtime?
  - `use_dotnet_isolated_runtime` - (Optional) Should the DotNet process use an isolated runtime. Defaults to `false`.
 

--- a/variables.tf
+++ b/variables.tf
@@ -1169,6 +1169,11 @@ variable "site_config" {
  - `node_version` - (Optional) The version of Node to run. Possible values include `12`, `14`, `16` and `18`.
  - `powershell_core_version` - (Optional) The version of PowerShell Core to run. Possible values are `7`, and `7.2`.
  - `python_version` - (Optional) The version of Python to run. Possible values are `3.12`, `3.11`, `3.10`, `3.9`, `3.8` and `3.7`.
+ - `go_version` - (Optional) The version of Go to use. Possible values are `1.18`, and `1.19`.
+ - `ruby_version` - (Optional) The version of Ruby to use. Possible values are `2.6`, and `2.7`.
+ - `java_server` - (Optional) The Java server type. Possible values are `JAVA`, `TOMCAT`, and `JBOSSEAP`.
+ - `java_server_version` - (Optional) The version of the Java server to use.
+ - `php_version` - (Optional) The version of PHP to use. Possible values are `7.4`, `8.0`, `8.1`, and `8.2`.
  - `use_custom_runtime` - (Optional) Should the Linux Function App use a custom runtime?
  - `use_dotnet_isolated_runtime` - (Optional) Should the DotNet process use an isolated runtime. Defaults to `false`.
 

--- a/variables.tf
+++ b/variables.tf
@@ -1065,6 +1065,11 @@ variable "site_config" {
       node_version                = optional(string)
       powershell_core_version     = optional(string)
       python_version              = optional(string)
+      go_version                  = optional(string)
+      ruby_version                = optional(string)
+      java_server                 = optional(string)
+      java_server_version         = optional(string)
+      php_version                 = optional(string)
       use_custom_runtime          = optional(bool)
       use_dotnet_isolated_runtime = optional(bool)
       docker = optional(list(object({


### PR DESCRIPTION
## Description
Fixes #31 

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
