### PR TITLE
Fix bug in slot private endpoint deployment

### DIFF
--- a/main.private_endpoints.tf
+++ b/main.private_endpoints.tf
@@ -114,25 +114,25 @@ resource "azurerm_private_endpoint" "slot" {
 resource "azurerm_private_endpoint" "slot_this_unmanaged_dns_zone_groups" {
   for_each = { for k, v in local.slot_pe : k => v if !var.private_endpoints_manage_dns_zone_group }
 
-  location                      = coalesce(each.value.location, var.location)
-  name                          = each.value.name != null ? each.value.name : "pep-${var.name}"
-  resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
-  subnet_id                     = each.value.subnet_resource_id
-  custom_network_interface_name = each.value.network_interface_name
-  tags                          = var.all_child_resources_inherit_tags ? merge(var.tags, each.value.tags) : each.value.tags
+  location                      = coalesce(each.value.pe_value.location, var.location)
+  name                          = each.value.pe_value.name != null ? each.value.pe_value.name : "pep-${var.name}"
+  resource_group_name           = each.value.pe_value.resource_group_name != null ? each.value.pe_value.resource_group_name : var.resource_group_name
+  subnet_id                     = each.value.pe_value.subnet_resource_id
+  custom_network_interface_name = each.value.pe_value.network_interface_name
+  tags                          = var.all_child_resources_inherit_tags ? merge(var.tags, each.value.pe_value.tags) : each.value.pe_value.tags
 
   private_service_connection {
     is_manual_connection           = false
-    name                           = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "pse-${var.name}"
+    name                           = each.value.pe_value.private_service_connection_name != null ? each.value.pe_value.private_service_connection_name : "pse-${var.name}"
     private_connection_resource_id = (var.kind == "functionapp" || var.kind == "webapp") ? (var.kind == "functionapp" ? (var.os_type == "Windows" ? azurerm_windows_function_app.this[0].id : azurerm_linux_function_app.this[0].id) : (var.os_type == "Windows" ? azurerm_windows_web_app.this[0].id : azurerm_linux_web_app.this[0].id)) : null
     subresource_names              = (var.kind == "functionapp" || var.kind == "webapp") ? (var.kind == "functionapp" ? (var.os_type == "Windows" ? ["sites-${coalesce(azurerm_windows_function_app_slot.this[each.value.slot_key].name, "pep-${var.name}")}"] : ["sites-${coalesce(azurerm_linux_function_app_slot.this[each.value.slot_key].name, "pep-${var.name}")}"]) : (var.os_type == "Windows" ? ["sites-${coalesce(azurerm_windows_web_app_slot.this[each.value.slot_key].name, "pep-${var.name}")}"] : ["sites-${coalesce(azurerm_linux_web_app_slot.this[each.value.slot_key].name, "pep-${var.name}")}"])) : null
   }
   dynamic "ip_configuration" {
-    for_each = each.value.ip_configurations
+    for_each = each.value.pe_value.ip_configurations
 
     content {
-      name               = ip_configuration.value.name
-      private_ip_address = ip_configuration.value.private_ip_address
+      name               = ip_configuration.value.pe_value.name
+      private_ip_address = ip_configuration.value.pe_value.private_ip_address
       member_name        = "sites"
       subresource_name   = "sites"
     }


### PR DESCRIPTION
## Description
The for.each value was not set properly resulting in the following error: 

`│   on .terraform/modules/xxxx/main.private_endpoints.tf line 136, in resource "azurerm_private_endpoint" "slot_this_unmanaged_dns_zone_groups":
│  136:     for_each = each.value.ip_configurations
│     ├────────────────
│     │ each.value is object with 3 attributes
│ 
│ This object does not have an attribute named "ip_configurations".
`

Setting the for each value to the proper object fixes the problem.

-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ x] Azure Verified Module updates:
  - [ x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ x] I'm sure there are no other open Pull Requests for the same update/change
- [ x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
