### PR TITLE
Bugfix/add missing defaults for request trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ map(object({
       requests = optional(object({
         count    = number
         interval = string
-      }))
+      }), {})
       slow_request = optional(map(object({
         count      = number
         interval   = string
@@ -1096,7 +1096,7 @@ map(object({
         requests = optional(object({
           count    = number
           interval = string
-        }))
+        }), {})
         slow_request = optional(map(object({
           count      = number
           interval   = string

--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ map(object({
       status_code = optional(map(object({
         count             = number
         interval          = string
-        status_code_range = number
+        status_code_range = string
         path              = optional(string)
         sub_status        = optional(number)
         win32_status_code = optional(number)
@@ -1112,7 +1112,7 @@ map(object({
         status_code = optional(map(object({
           count             = number
           interval          = string
-          status_code_range = number
+          status_code_range = string
           path              = optional(string)
           sub_status        = optional(number)
           win32_status_code = optional(number)

--- a/variables.slots.tf
+++ b/variables.slots.tf
@@ -219,10 +219,10 @@ variable "deployment_slots" {
       }))
       trigger = optional(object({
         private_memory_kb = optional(number)
-        requests = optional(object({
+        requests = optional(map(object({
           count    = number
           interval = string
-        }), {})
+        })), {})
         slow_request = optional(map(object({
           count      = number
           interval   = string

--- a/variables.slots.tf
+++ b/variables.slots.tf
@@ -222,7 +222,7 @@ variable "deployment_slots" {
         requests = optional(object({
           count    = number
           interval = string
-        }))
+        }), {})
         slow_request = optional(map(object({
           count      = number
           interval   = string

--- a/variables.slots.tf
+++ b/variables.slots.tf
@@ -9,7 +9,7 @@ variable "app_service_active_slot" {
   ```
   Object that sets the active slot for the App Service.
 
-  `slot_key` - The key of the slot object to set as active. 
+  `slot_key` - The key of the slot object to set as active.
   `overwrite_network_config` - Determines if the network configuration should be overwritten. Defaults to `true`.
 
   ```
@@ -238,7 +238,7 @@ variable "deployment_slots" {
         status_code = optional(map(object({
           count             = number
           interval          = string
-          status_code_range = number
+          status_code_range = string
           path              = optional(string)
           sub_status        = optional(number)
           win32_status_code = optional(number)

--- a/variables.tf
+++ b/variables.tf
@@ -502,7 +502,7 @@ variable "auto_heal_setting" {
       status_code = optional(map(object({
         count             = number
         interval          = string
-        status_code_range = number
+        status_code_range = string
         path              = optional(string)
         sub_status        = optional(number)
         win32_status_code = optional(number)

--- a/variables.tf
+++ b/variables.tf
@@ -486,7 +486,7 @@ variable "auto_heal_setting" {
       requests = optional(object({
         count    = number
         interval = string
-      }))
+      }), {})
       slow_request = optional(map(object({
         count      = number
         interval   = string

--- a/variables.tf
+++ b/variables.tf
@@ -483,10 +483,10 @@ variable "auto_heal_setting" {
     }))
     trigger = optional(object({
       private_memory_kb = optional(number)
-      requests = optional(object({
+      requests = optional(map(object({
         count    = number
         interval = string
-      }), {})
+      })), {})
       slow_request = optional(map(object({
         count      = number
         interval   = string


### PR DESCRIPTION
## Description

* Adds a default empty object for the `requests` trigger to match all other trigger types and resolve the problem of the `requests` triggers properties being required even when not using the trigger type.
* Updates the definition of status_code_rage within the auto_heal_settings variables to be a string type rather than a number. The underlying azurerm provider accepts a string and allows the value to be either a single status code or a range in the format of 500-599

Closes #177, and Closes #179.


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
