### PR TITLE
Fixes for Auto Scaling Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ Description:
     - `slow_request` - (Optional) The slow request trigger to activate the action.
       - `count` - (Required) The number of slow requests to trigger the action.
       - `interval` - (Required) The interval to trigger the action.
-      - `take_taken` - (Required) The time taken to trigger the action.
+      - `time_taken` - (Required) The time taken to trigger the action.
       - `path` - (Optional) The path to trigger the action.
       > NOTE: The `path` property in the `slow_request` block is deprecated and will be removed in 4.0 of provider. Please use `slow_request_with_path` to set a slow request trigger with `path` specified.
     - `status_code` - (Optional) The status code trigger to activate the action.
@@ -655,13 +655,13 @@ map(object({
       slow_request = optional(map(object({
         count      = number
         interval   = string
-        take_taken = string
+        time_taken = string
         path       = optional(string)
       })), {})
       slow_request_with_path = optional(map(object({
         count      = number
         interval   = string
-        take_taken = string
+        time_taken = string
         path       = optional(string)
       })), {})
       status_code = optional(map(object({
@@ -1100,13 +1100,13 @@ map(object({
         slow_request = optional(map(object({
           count      = number
           interval   = string
-          take_taken = string
+          time_taken = string
           path       = optional(string)
         })), {})
         slow_request_with_path = optional(map(object({
           count      = number
           interval   = string
-          take_taken = string
+          time_taken = string
           path       = optional(string)
         })), {})
         status_code = optional(map(object({

--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ map(object({
       status_code = optional(map(object({
         count             = number
         interval          = string
-        status_code_range = number
+        status_code_range = string
         path              = optional(string)
         sub_status        = optional(number)
         win32_status_code = optional(number)
@@ -1112,7 +1112,7 @@ map(object({
         status_code = optional(map(object({
           count             = number
           interval          = string
-          status_code_range = number
+          status_code_range = string
           path              = optional(string)
           sub_status        = optional(number)
           win32_status_code = optional(number)

--- a/README.md
+++ b/README.md
@@ -648,10 +648,10 @@ map(object({
     }))
     trigger = optional(object({
       private_memory_kb = optional(number)
-      requests = optional(object({
+      requests = optional(map(object({
         count    = number
         interval = string
-      }), {})
+      })), {})
       slow_request = optional(map(object({
         count      = number
         interval   = string
@@ -1093,10 +1093,10 @@ map(object({
       }))
       trigger = optional(object({
         private_memory_kb = optional(number)
-        requests = optional(object({
+        requests = optional(map(object({
           count    = number
           interval = string
-        }), {})
+        })), {})
         slow_request = optional(map(object({
           count      = number
           interval   = string

--- a/main.web_app.tf
+++ b/main.web_app.tf
@@ -52,9 +52,9 @@ resource "azurerm_windows_web_app" "this" {
       content {
         current_stack = application_stack.value.current_stack
         # No longer supported in azurerm 4.x
-        # docker_container_name        = application_stack.value.docker_container_name 
+        # docker_container_name        = application_stack.value.docker_container_name
         # No longer supported in azurerm 4.x
-        # docker_container_tag         = application_stack.value.docker_container_tag  
+        # docker_container_tag         = application_stack.value.docker_container_tag
         docker_image_name            = application_stack.value.docker_image_name
         docker_registry_password     = application_stack.value.docker_registry_password
         docker_registry_url          = application_stack.value.docker_registry_url
@@ -80,27 +80,31 @@ resource "azurerm_windows_web_app" "this" {
         trigger {
           private_memory_kb = auto_heal_setting.value.trigger.private_memory_kb
 
-          requests {
-            count    = auto_heal_setting.value.trigger.requests.count
-            interval = auto_heal_setting.value.trigger.requests.interval
+          dynamic "requests" {
+            for_each = auto_heal_setting.value.trigger.requests
+            content{
+              count    = requests.value.trigger.requests.count
+              interval = requests.value.trigger.requests.interval
+            }
           }
+
           dynamic "slow_request" {
             for_each = auto_heal_setting.value.trigger.slow_request
 
             content {
-              count      = slow_requests.value.count
-              interval   = slow_requests.value.interval
-              time_taken = slow_requests.value.time_taken
+              count      = slow_request.value.count
+              interval   = slow_request.value.interval
+              time_taken = slow_request.value.time_taken
             }
           }
           dynamic "slow_request_with_path" {
             for_each = auto_heal_setting.value.trigger.slow_request_with_path
 
             content {
-              count      = slow_requests_with_path.value.count
-              interval   = slow_requests_with_path.value.interval
-              time_taken = slow_requests_with_path.value.time_taken
-              path       = slow_requests_with_path.value.path
+              count      = slow_request_with_path.value.count
+              interval   = slow_request_with_path.value.interval
+              time_taken = slow_request_with_path.value.time_taken
+              path       = slow_request_with_path.value.path
             }
           }
           dynamic "status_code" {
@@ -150,7 +154,7 @@ resource "azurerm_windows_web_app" "this" {
       }
     }
     dynamic "scm_ip_restriction" {
-      # one or more scm_ip_restriction blocks 
+      # one or more scm_ip_restriction blocks
       for_each = var.site_config.scm_ip_restriction
 
       content {
@@ -599,27 +603,30 @@ resource "azurerm_linux_web_app" "this" {
           minimum_process_execution_time = auto_heal_setting.value.action.minimum_process_execution_time
         }
         trigger {
-          requests {
-            count    = auto_heal_setting.value.trigger.requests.count
-            interval = auto_heal_setting.value.trigger.requests.interval
+          dynamic "requests" {
+            for_each = auto_heal_setting.value.trigger.requests
+            content{
+              count    = requests.value.trigger.requests.count
+              interval = requests.value.trigger.requests.interval
+            }
           }
           dynamic "slow_request" {
             for_each = auto_heal_setting.value.trigger.slow_request
 
             content {
-              count      = slow_requests.value.count
-              interval   = slow_requests.value.interval
-              time_taken = slow_requests.value.time_taken
+              count      = slow_request.value.count
+              interval   = slow_request.value.interval
+              time_taken = slow_request.value.time_taken
             }
           }
           dynamic "slow_request_with_path" {
             for_each = auto_heal_setting.value.trigger.slow_request_with_path
 
             content {
-              count      = slow_requests_with_path.value.count
-              interval   = slow_requests_with_path.value.interval
-              time_taken = slow_requests_with_path.value.time_taken
-              path       = slow_requests_with_path.value.path
+              count      = slow_request_with_path.value.count
+              interval   = slow_request_with_path.value.interval
+              time_taken = slow_request_with_path.value.time_taken
+              path       = slow_request_with_path.value.path
             }
           }
           dynamic "status_code" {
@@ -669,7 +676,7 @@ resource "azurerm_linux_web_app" "this" {
       }
     }
     dynamic "scm_ip_restriction" {
-      # one or more scm_ip_restriction blocks 
+      # one or more scm_ip_restriction blocks
       for_each = var.site_config.scm_ip_restriction
 
       content {

--- a/main.web_app_slots.tf
+++ b/main.web_app_slots.tf
@@ -75,27 +75,30 @@ resource "azurerm_windows_web_app_slot" "this" {
         trigger {
           private_memory_kb = auto_heal_setting.value.trigger.private_memory_kb
 
-          requests {
-            count    = auto_heal_setting.value.trigger.requests.count
-            interval = auto_heal_setting.value.trigger.requests.interval
+          dynamic "requests" {
+            for_each = auto_heal_setting.value.trigger.requests
+            content {
+              count    = requests.value.trigger.requests.count
+              interval = requests.value.trigger.requests.interval
+            }
           }
           dynamic "slow_request" {
             for_each = auto_heal_setting.value.trigger.slow_request
 
             content {
-              count      = slow_requests.value.count
-              interval   = slow_requests.value.interval
-              time_taken = slow_requests.value.time_taken
+              count      = slow_request.value.count
+              interval   = slow_request.value.interval
+              time_taken = slow_request.value.time_taken
             }
           }
           dynamic "slow_request_with_path" {
             for_each = auto_heal_setting.value.trigger.slow_request_with_path
 
             content {
-              count      = slow_requests_with_path.value.count
-              interval   = slow_requests_with_path.value.interval
-              time_taken = slow_requests_with_path.value.time_taken
-              path       = slow_requests_with_path.value.path
+              count      = slow_request_with_path.value.count
+              interval   = slow_request_with_path.value.interval
+              time_taken = slow_request_with_path.value.time_taken
+              path       = slow_request_with_path.value.path
             }
           }
           dynamic "status_code" {
@@ -581,27 +584,30 @@ resource "azurerm_linux_web_app_slot" "this" {
           minimum_process_execution_time = auto_heal_setting.value.action.minimum_process_execution_time
         }
         trigger {
-          requests {
-            count    = auto_heal_setting.value.trigger.requests.count
-            interval = auto_heal_setting.value.trigger.requests.interval
+          dynamic "requests" {
+            for_each = auto_heal_setting.value.trigger.requests
+            content {
+              count    = requests.value.trigger.requests.count
+              interval = requests.value.trigger.requests.interval
+            }
           }
           dynamic "slow_request" {
             for_each = auto_heal_setting.value.trigger.slow_request
 
             content {
-              count      = slow_requests.value.count
-              interval   = slow_requests.value.interval
-              time_taken = slow_requests.value.time_taken
+              count      = slow_request.value.count
+              interval   = slow_request.value.interval
+              time_taken = slow_request.value.time_taken
             }
           }
           dynamic "slow_request_with_path" {
             for_each = auto_heal_setting.value.trigger.slow_request_with_path
 
             content {
-              count      = slow_requests_with_path.value.count
-              interval   = slow_requests_with_path.value.interval
-              time_taken = slow_requests_with_path.value.time_taken
-              path       = slow_requests_with_path.value.path
+              count      = slow_request_with_path.value.count
+              interval   = slow_request_with_path.value.interval
+              time_taken = slow_request_with_path.value.time_taken
+              path       = slow_request_with_path.value.path
             }
           }
           dynamic "status_code" {
@@ -651,7 +657,7 @@ resource "azurerm_linux_web_app_slot" "this" {
       }
     }
     dynamic "scm_ip_restriction" {
-      # one or more scm_ip_restriction blocks 
+      # one or more scm_ip_restriction blocks
       for_each = each.value.site_config.scm_ip_restriction
 
       content {

--- a/variables.slots.tf
+++ b/variables.slots.tf
@@ -226,13 +226,13 @@ variable "deployment_slots" {
         slow_request = optional(map(object({
           count      = number
           interval   = string
-          take_taken = string
+          time_taken = string
           path       = optional(string)
         })), {})
         slow_request_with_path = optional(map(object({
           count      = number
           interval   = string
-          take_taken = string
+          time_taken = string
           path       = optional(string)
         })), {})
         status_code = optional(map(object({

--- a/variables.slots.tf
+++ b/variables.slots.tf
@@ -9,7 +9,7 @@ variable "app_service_active_slot" {
   ```
   Object that sets the active slot for the App Service.
 
-  `slot_key` - The key of the slot object to set as active. 
+  `slot_key` - The key of the slot object to set as active.
   `overwrite_network_config` - Determines if the network configuration should be overwritten. Defaults to `true`.
 
   ```
@@ -238,7 +238,7 @@ variable "deployment_slots" {
         status_code = optional(map(object({
           count             = number
           interval          = string
-          status_code_range = number
+          status_code_range = string
           path              = optional(string)
           sub_status        = optional(number)
           win32_status_code = optional(number)

--- a/variables.tf
+++ b/variables.tf
@@ -502,7 +502,7 @@ variable "auto_heal_setting" {
       status_code = optional(map(object({
         count             = number
         interval          = string
-        status_code_range = number
+        status_code_range = string
         path              = optional(string)
         sub_status        = optional(number)
         win32_status_code = optional(number)

--- a/variables.tf
+++ b/variables.tf
@@ -490,13 +490,13 @@ variable "auto_heal_setting" {
       slow_request = optional(map(object({
         count      = number
         interval   = string
-        take_taken = string
+        time_taken = string
         path       = optional(string)
       })), {})
       slow_request_with_path = optional(map(object({
         count      = number
         interval   = string
-        take_taken = string
+        time_taken = string
         path       = optional(string)
       })), {})
       status_code = optional(map(object({
@@ -530,7 +530,7 @@ variable "auto_heal_setting" {
     - `slow_request` - (Optional) The slow request trigger to activate the action.
       - `count` - (Required) The number of slow requests to trigger the action.
       - `interval` - (Required) The interval to trigger the action.
-      - `take_taken` - (Required) The time taken to trigger the action.
+      - `time_taken` - (Required) The time taken to trigger the action.
       - `path` - (Optional) The path to trigger the action.
       > NOTE: The `path` property in the `slow_request` block is deprecated and will be removed in 4.0 of provider. Please use `slow_request_with_path` to set a slow request trigger with `path` specified.
     - `status_code` - (Optional) The status code trigger to activate the action.


### PR DESCRIPTION
## Description

* Closes #177 
Adds a default empty object for the `requests` trigger to match all other trigger types and resolve the problem of the `requests` triggers properties being required even when not using the trigger type. Also updates the `requests` trigger in the resource implementation to use a dynamic and for_each to match all other trigger implementations.

* Closes #179 
Updates the definition of status_code_rage within the auto_heal_settings variables to be a string type rather than a number. The underlying azurerm provider accepts a string and allows the value to be either a single status code or a range in the format of 500-599

* Closes #181 
Rename the variable `take_taken` to `time_taken` to match the implementations in web app, function app, etc.

* Closes #183 
Update the implementation of the `slow_request` and `slow_requests` dynamic names

* Run `terraform-docs` to update documentation after changes


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
