### PR TITLE
feat: add support for 512 as a valid value for instance_memory_in_mb

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -916,8 +916,8 @@ variable "instance_memory_in_mb" {
   description = "The amount of memory to allocate for the instance(s)."
 
   validation {
-    error_message = "The value must be on of: `2048 or `4096`"
-    condition     = contains([2048, 4096], var.instance_memory_in_mb)
+    error_message = "The value must be on of: `512`, `2048`, or `4096`"
+    condition     = contains([512, 2048, 4096], var.instance_memory_in_mb)
   }
 }
 


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->
This PR updates the validation rule for the instance_memory_in_mb variable.
Previously, the allowed values were limited to `2048` and `4096`.
With this change, `512` is now supported as a valid option.

ref: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan#instance-memory

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
