### PR TITLE
fix(logs): emit logs block when azure_blob_storage is configured

### DIFF
--- a/main.web_app.tf
+++ b/main.web_app.tf
@@ -451,7 +451,7 @@ resource "azurerm_windows_web_app" "this" {
     # Emit logs when file system logging is enabled or when blob logging is configured.
     for_each = local.webapp_keys.alk != null ? [
       for x in var.logs :
-      x if (
+      x if(
         (
           x.application_logs[local.webapp_keys.alk].file_system_level != null &&
           x.application_logs[local.webapp_keys.alk].file_system_level != "Off"
@@ -968,7 +968,7 @@ resource "azurerm_linux_web_app" "this" {
     # Emit logs when file system logging is enabled or when blob logging is configured.
     for_each = local.webapp_keys.alk != null ? [
       for x in var.logs :
-      x if (
+      x if(
         (
           x.application_logs[local.webapp_keys.alk].file_system_level != null &&
           x.application_logs[local.webapp_keys.alk].file_system_level != "Off"

--- a/main.web_app_slots.tf
+++ b/main.web_app_slots.tf
@@ -440,7 +440,7 @@ resource "azurerm_windows_web_app_slot" "this" {
   dynamic "logs" {
     # Emit logs when file system logging is enabled or when blob logging is configured.
     for_each = contains(local.webapp_slots_with_logs_keys, each.key) ? {
-      for k, v in each.value.logs : k => v if (
+      for k, v in each.value.logs : k => v if(
         (
           v.application_logs[local.webapp_slot_lk[each.key].file_system_level_key].file_system_level != null &&
           lower(v.application_logs[local.webapp_slot_lk[each.key].file_system_level_key].file_system_level) != "off"
@@ -944,7 +944,7 @@ resource "azurerm_linux_web_app_slot" "this" {
   dynamic "logs" {
     # Emit logs when file system logging is enabled or when blob logging is configured.
     for_each = contains(local.webapp_slots_with_logs_keys, each.key) ? {
-      for k, v in each.value.logs : k => v if (
+      for k, v in each.value.logs : k => v if(
         (
           v.application_logs[local.webapp_slot_lk[each.key].file_system_level_key].file_system_level != null &&
           lower(v.application_logs[local.webapp_slot_lk[each.key].file_system_level_key].file_system_level) != "off"


### PR DESCRIPTION
## Description
Update the dynamic logs for_each condition in web app and slot resources to also emit the logs block when azure_blob_storage is configured, not only when file_system_level is enabled.

This allows application logging to blob storage even when file system logging is set to 'Off' or null.

Affected resources:
- azurerm_windows_web_app.this
- azurerm_linux_web_app.this
- azurerm_windows_web_app_slot.this
- azurerm_linux_web_app_slot.this

Fixes #[250](https://github.com/Azure/terraform-azurerm-avm-res-web-site/issues/250)

