### PR TITLE
`bugfix`: emit logs block when azure_blob_storage is configured (#251)

### DIFF
--- a/main.web_app.tf
+++ b/main.web_app.tf
@@ -448,8 +448,17 @@ resource "azurerm_windows_web_app" "this" {
   dynamic "logs" {
     # If the `application_logs` key is not null... means that if `application_logs` is populated
     # For each log object in var.logs (there should only ever be one in practice...)
-    # Check if instance of `logs` where the `application_logs` key is <key_value> and if file_system_level is not configured to "Off" or null
-    for_each = local.webapp_keys.alk != null ? [for x in var.logs : x if(x.application_logs[local.webapp_keys.alk].file_system_level != "Off" && x.application_logs[local.webapp_keys.alk].file_system_level != null)] : []
+    # Emit logs when file system logging is enabled or when blob logging is configured.
+    for_each = local.webapp_keys.alk != null ? [
+      for x in var.logs :
+      x if(
+        (
+          x.application_logs[local.webapp_keys.alk].file_system_level != null &&
+          x.application_logs[local.webapp_keys.alk].file_system_level != "Off"
+        ) ||
+        x.application_logs[local.webapp_keys.alk].azure_blob_storage != null
+      )
+    ] : []
 
     content {
       detailed_error_messages = logs.value.detailed_error_messages
@@ -956,8 +965,17 @@ resource "azurerm_linux_web_app" "this" {
   dynamic "logs" {
     # If the `application_logs` key is not null... means that if `application_logs` is populated
     # For each log object in var.logs (there should only ever be one in practice...)
-    # Check if instance of `logs` where the `application_logs` key is <key_value> and if file_system_level is not configured to "Off" or null
-    for_each = local.webapp_keys.alk != null ? [for x in var.logs : x if(x.application_logs[local.webapp_keys.alk].file_system_level != "Off" && x.application_logs[local.webapp_keys.alk].file_system_level != null)] : []
+    # Emit logs when file system logging is enabled or when blob logging is configured.
+    for_each = local.webapp_keys.alk != null ? [
+      for x in var.logs :
+      x if(
+        (
+          x.application_logs[local.webapp_keys.alk].file_system_level != null &&
+          x.application_logs[local.webapp_keys.alk].file_system_level != "Off"
+        ) ||
+        x.application_logs[local.webapp_keys.alk].azure_blob_storage != null
+      )
+    ] : []
 
     content {
       detailed_error_messages = logs.value.detailed_error_messages

--- a/main.web_app_slots.tf
+++ b/main.web_app_slots.tf
@@ -438,7 +438,16 @@ resource "azurerm_windows_web_app_slot" "this" {
     }
   }
   dynamic "logs" {
-    for_each = contains(local.webapp_slots_with_logs_keys, each.key) ? { for k, v in each.value.logs : k => v if(lower(v.application_logs[local.webapp_slot_lk[each.key].file_system_level_key].file_system_level)) != "off" && v.application_logs[local.webapp_slot_lk[each.key].file_system_level_key].file_system_level != null } : {}
+    # Emit logs when file system logging is enabled or when blob logging is configured.
+    for_each = contains(local.webapp_slots_with_logs_keys, each.key) ? {
+      for k, v in each.value.logs : k => v if(
+        (
+          v.application_logs[local.webapp_slot_lk[each.key].file_system_level_key].file_system_level != null &&
+          lower(v.application_logs[local.webapp_slot_lk[each.key].file_system_level_key].file_system_level) != "off"
+        ) ||
+        v.application_logs[local.webapp_slot_lk[each.key].file_system_level_key].azure_blob_storage != null
+      )
+    } : {}
 
     content {
       detailed_error_messages = logs.value.detailed_error_messages
@@ -933,7 +942,16 @@ resource "azurerm_linux_web_app_slot" "this" {
     }
   }
   dynamic "logs" {
-    for_each = contains(local.webapp_slots_with_logs_keys, each.key) ? { for k, v in each.value.logs : k => v if(lower(v.application_logs[local.webapp_slot_lk[each.key].file_system_level_key].file_system_level)) != "off" && v.application_logs[local.webapp_slot_lk[each.key].file_system_level_key].file_system_level != null } : {}
+    # Emit logs when file system logging is enabled or when blob logging is configured.
+    for_each = contains(local.webapp_slots_with_logs_keys, each.key) ? {
+      for k, v in each.value.logs : k => v if(
+        (
+          v.application_logs[local.webapp_slot_lk[each.key].file_system_level_key].file_system_level != null &&
+          lower(v.application_logs[local.webapp_slot_lk[each.key].file_system_level_key].file_system_level) != "off"
+        ) ||
+        v.application_logs[local.webapp_slot_lk[each.key].file_system_level_key].azure_blob_storage != null
+      )
+    } : {}
 
     content {
       detailed_error_messages = logs.value.detailed_error_messages


### PR DESCRIPTION
* fix(logs): emit logs block when azure_blob_storage is configured

Update the dynamic logs for_each condition in web app and slot resources to also emit the logs block when azure_blob_storage is configured, not only when file_system_level is enabled.

This allows application logging to blob storage even when file system logging is set to 'Off' or null.

Affected resources:
- azurerm_windows_web_app.this
- azurerm_linux_web_app.this
- azurerm_windows_web_app_slot.this
- azurerm_linux_web_app_slot.this

* changes after pre-commit

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
