### PR TITLE
feat: update zip deploy to use OneDeploy extension API

### DIFF
--- a/modules/extensions_zipdeploy/main.tf
+++ b/modules/extensions_zipdeploy/main.tf
@@ -1,10 +1,13 @@
 resource "azapi_resource_action" "this" {
-  action      = "extensions/zipdeploy"
+  action      = "extensions/onedeploy"
   method      = "PUT"
   resource_id = var.parent_id
   type        = local.type
   body = {
-    packageUri = var.zip_deploy_file
+    properties = {
+      packageUri = var.zip_deploy_file
+      type       = "zip"
+    }
   }
 
   lifecycle {

--- a/modules/extensions_zipdeploy/outputs.tf
+++ b/modules/extensions_zipdeploy/outputs.tf
@@ -1,6 +1,6 @@
 output "name" {
   description = "The name of the deploy action."
-  value       = "zipdeploy"
+  value       = "onedeploy"
 }
 
 output "resource" {


### PR DESCRIPTION
## Description

Replace the deprecated extensions/zipdeploy action with the newer extensions/onedeploy API.

### Changes
- Action: extensions/zipdeploy to extensions/onedeploy
- Body: Wrapped in properties and added type=zip as required by the OneDeploy API spec
- Output: Updated the name output from zipdeploy to onedeploy

The module name/directory and variable name remain unchanged to avoid breaking the public interface.
