### PR TITLE
feat: add retry variable to all azapi resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1615,6 +1615,34 @@ object({
 
 Default: `null`
 
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for all azapi resources. Defaults to retrying on 409 Conflict errors caused by concurrent operations.
+
+- `error_message_regex` - (Required) A list of regular expressions to match against error messages. If any match, the operation will be retried.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries. Defaults to `10`.
+- `max_retries` - (Optional) The maximum number of retries. Defaults to `3`.
+
+Type:
+
+```hcl
+object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+```
+
+Default:
+
+```json
+{
+  "error_message_regex": [
+    "Cannot modify this site because another operation is in progress"
+  ]
+}
+```
+
 ### <a name="input_role_assignments"></a> [role\_assignments](#input\_role\_assignments)
 
 Description: A map of role assignments to create on this resource. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.

--- a/examples/windows_dotnet10/README.md
+++ b/examples/windows_dotnet10/README.md
@@ -37,7 +37,7 @@ resource "azapi_resource" "service_plan" {
   body = {
     kind = "app"
     sku = {
-      name = "P1v2"
+      name = "P1v3"
     }
     properties = {
       reserved      = false

--- a/examples/windows_dotnet10/main.tf
+++ b/examples/windows_dotnet10/main.tf
@@ -26,7 +26,7 @@ resource "azapi_resource" "service_plan" {
   body = {
     kind = "app"
     sku = {
-      name = "P1v2"
+      name = "P1v3"
     }
     properties = {
       reserved      = false

--- a/main.auth.tf
+++ b/main.auth.tf
@@ -15,6 +15,7 @@ module "config_authsettings" {
   google                         = each.value.google
   issuer                         = each.value.issuer
   microsoft                      = each.value.microsoft
+  retry                          = var.retry
   runtime_version                = each.value.runtime_version
   token_refresh_extension_hours  = each.value.token_refresh_extension_hours
   token_store_enabled            = each.value.token_store_enabled
@@ -39,6 +40,7 @@ module "config_authsettingsv2" {
   redirect_to_provider                   = each.value.redirect_to_provider
   require_authentication                 = each.value.require_authentication
   require_https                          = each.value.require_https
+  retry                                  = var.retry
   runtime_version                        = each.value.runtime_version
   unauthenticated_client_action          = each.value.unauthenticated_client_action
 }

--- a/main.backup.tf
+++ b/main.backup.tf
@@ -5,6 +5,7 @@ module "config_backup" {
   parent_id   = azapi_resource.this.id
   backup_name = coalesce(each.value.name, "backup-${var.name}")
   enabled     = each.value.enabled
+  retry       = var.retry
   schedule = each.value.schedule != null ? {
     for sk, sv in each.value.schedule : sk => sv
   }[keys(each.value.schedule)[0]] : null

--- a/main.config.tf
+++ b/main.config.tf
@@ -3,6 +3,7 @@ module "config_appsettings" {
 
   app_settings = local.merged_app_settings
   parent_id    = azapi_resource.this.id
+  retry        = var.retry
 }
 
 module "config_connectionstrings" {
@@ -10,6 +11,7 @@ module "config_connectionstrings" {
 
   connection_strings = var.connection_strings
   parent_id          = azapi_resource.this.id
+  retry              = var.retry
 }
 
 module "config_azurestorageaccounts" {
@@ -17,6 +19,7 @@ module "config_azurestorageaccounts" {
 
   parent_id               = azapi_resource.this.id
   storage_shares_to_mount = var.storage_shares_to_mount
+  retry                   = var.retry
 }
 
 module "config_metadata" {
@@ -24,6 +27,7 @@ module "config_metadata" {
 
   metadata  = { for m in coalesce(module.site_config_helpers.site_config_metadata, []) : m.name => m.value }
   parent_id = azapi_resource.this.id
+  retry     = var.retry
 }
 
 module "config_slotconfignames" {
@@ -33,6 +37,7 @@ module "config_slotconfignames" {
   parent_id               = azapi_resource.this.id
   app_setting_names       = flatten([for k, v in var.sticky_settings : coalesce(v.app_setting_names, [])])
   connection_string_names = flatten([for k, v in var.sticky_settings : coalesce(v.connection_string_names, [])])
+  retry                   = var.retry
 }
 
 module "ftp_publishing_credential_policy" {
@@ -42,6 +47,7 @@ module "ftp_publishing_credential_policy" {
   name      = "ftp"
   parent_id = azapi_resource.this.id
   allow     = false
+  retry     = var.retry
 }
 
 module "scm_publishing_credential_policy" {
@@ -51,4 +57,5 @@ module "scm_publishing_credential_policy" {
   name      = "scm"
   parent_id = azapi_resource.this.id
   allow     = false
+  retry     = var.retry
 }

--- a/main.custom_domains.tf
+++ b/main.custom_domains.tf
@@ -4,6 +4,7 @@ module "hostname_binding" {
 
   hostname   = each.value.hostname
   parent_id  = azapi_resource.this.id
+  retry      = var.retry
   ssl_state  = each.value.ssl_state
   thumbprint = each.value.thumbprint
 }
@@ -14,6 +15,7 @@ module "slot_hostname_binding" {
 
   hostname   = each.value.hostname
   parent_id  = module.slot[each.value.app_service_slot_key].resource_id
+  retry      = var.retry
   ssl_state  = each.value.ssl_state
   thumbprint = each.value.thumbprint
 }

--- a/main.deploy.tf
+++ b/main.deploy.tf
@@ -20,6 +20,7 @@ module "extensions_zipdeploy" {
 
   parent_id       = azapi_resource.this.id
   zip_deploy_file = var.zip_deploy_file
+  retry           = var.retry
 
   depends_on = [
     time_sleep.wait_before_zip_deploy,

--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -27,6 +27,7 @@ resource "azapi_resource" "lock" {
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
 
@@ -42,6 +43,7 @@ resource "azapi_resource" "role_assignment" {
   ignore_null_property   = true
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
 
@@ -57,6 +59,7 @@ resource "azapi_resource" "private_endpoint" {
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   tags                   = each.value.tags
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
@@ -72,6 +75,7 @@ resource "azapi_resource" "private_dns_zone_group" {
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
 
@@ -86,6 +90,7 @@ resource "azapi_resource" "lock_private_endpoint" {
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
 
@@ -100,6 +105,7 @@ resource "azapi_resource" "role_assignment_private_endpoint" {
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
 
@@ -115,6 +121,7 @@ resource "azapi_resource" "diagnostic_setting" {
   ignore_null_property   = true
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
 

--- a/main.logs.tf
+++ b/main.logs.tf
@@ -11,4 +11,5 @@ module "config_logs" {
   http_logs = length(each.value.http_logs) > 0 ? {
     for hlk, hlv in each.value.http_logs : hlk => hlv
   }[keys(each.value.http_logs)[0]] : null
+  retry = var.retry
 }

--- a/main.slots.tf
+++ b/main.slots.tf
@@ -47,6 +47,7 @@ module "slot" {
   public_network_access_enabled           = each.value.public_network_access_enabled
   redundancy_mode                         = each.value.redundancy_mode
   resource_config                         = each.value.resource_config
+  retry                                   = var.retry
   role_assignments                        = each.value.role_assignments
   scm_site_also_stopped                   = each.value.scm_site_also_stopped
   sensitive_app_settings                  = lookup(var.slot_sensitive_app_settings, each.key, {})
@@ -83,6 +84,7 @@ resource "azapi_resource_action" "active_slot" {
     targetSlot   = coalesce(var.deployment_slots[var.app_service_active_slot.slot_key].name, var.app_service_active_slot.slot_key)
     preserveVnet = !var.app_service_active_slot.overwrite_network_config
   }
+  retry = var.retry
 
   depends_on = [module.slot]
 }

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ resource "azapi_resource" "this" {
     "properties.defaultHostName",
     "identity.principalId",
   ]
+  retry          = var.retry
   tags           = var.tags
   update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 

--- a/modules/config_appsettings/README.md
+++ b/modules/config_appsettings/README.md
@@ -50,6 +50,30 @@ Type: `bool`
 
 Default: `false`
 
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for azapi resources.
+
+Type:
+
+```hcl
+object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+```
+
+Default:
+
+```json
+{
+  "error_message_regex": [
+    "Cannot modify this site because another operation is in progress"
+  ]
+}
+```
+
 ## Outputs
 
 The following outputs are exported:

--- a/modules/config_appsettings/main.tf
+++ b/modules/config_appsettings/main.tf
@@ -6,4 +6,5 @@ resource "azapi_update_resource" "this" {
     properties = var.app_settings
   }
   response_export_values = []
+  retry                  = var.retry
 }

--- a/modules/config_appsettings/variables.tf
+++ b/modules/config_appsettings/variables.tf
@@ -23,3 +23,15 @@ variable "is_slot" {
   default     = false
   description = "Whether the parent resource is a deployment slot. Defaults to `false`."
 }
+
+variable "retry" {
+  type = object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+  default = {
+    error_message_regex = ["Cannot modify this site because another operation is in progress"]
+  }
+  description = "Retry configuration for azapi resources."
+}

--- a/modules/config_authsettings/README.md
+++ b/modules/config_authsettings/README.md
@@ -188,6 +188,30 @@ object({
 
 Default: `null`
 
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for azapi resources.
+
+Type:
+
+```hcl
+object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+```
+
+Default:
+
+```json
+{
+  "error_message_regex": [
+    "Cannot modify this site because another operation is in progress"
+  ]
+}
+```
+
 ### <a name="input_runtime_version"></a> [runtime\_version](#input\_runtime\_version)
 
 Description: The runtime version of the authentication module.

--- a/modules/config_authsettings/main.tf
+++ b/modules/config_authsettings/main.tf
@@ -49,4 +49,5 @@ resource "azapi_update_resource" "this" {
     }
   }
   response_export_values = []
+  retry                  = var.retry
 }

--- a/modules/config_authsettings/variables.tf
+++ b/modules/config_authsettings/variables.tf
@@ -129,6 +129,18 @@ Microsoft authentication configuration.
 DESCRIPTION
 }
 
+variable "retry" {
+  type = object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+  default = {
+    error_message_regex = ["Cannot modify this site because another operation is in progress"]
+  }
+  description = "Retry configuration for azapi resources."
+}
+
 variable "runtime_version" {
   type        = string
   default     = null

--- a/modules/config_authsettingsv2/README.md
+++ b/modules/config_authsettingsv2/README.md
@@ -393,6 +393,30 @@ Type: `bool`
 
 Default: `true`
 
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for azapi resources.
+
+Type:
+
+```hcl
+object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+```
+
+Default:
+
+```json
+{
+  "error_message_regex": [
+    "Cannot modify this site because another operation is in progress"
+  ]
+}
+```
+
 ### <a name="input_runtime_version"></a> [runtime\_version](#input\_runtime\_version)
 
 Description: The runtime version of the auth module. Defaults to `~1`.

--- a/modules/config_authsettingsv2/main.tf
+++ b/modules/config_authsettingsv2/main.tf
@@ -25,4 +25,5 @@ resource "azapi_update_resource" "this" {
     )
   }
   response_export_values = []
+  retry                  = var.retry
 }

--- a/modules/config_authsettingsv2/variables.tf
+++ b/modules/config_authsettingsv2/variables.tf
@@ -338,6 +338,18 @@ variable "require_https" {
   description = "Should HTTPS be required? Defaults to `true`."
 }
 
+variable "retry" {
+  type = object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+  default = {
+    error_message_regex = ["Cannot modify this site because another operation is in progress"]
+  }
+  description = "Retry configuration for azapi resources."
+}
+
 variable "runtime_version" {
   type        = string
   default     = "~1"

--- a/modules/config_azurestorageaccounts/README.md
+++ b/modules/config_azurestorageaccounts/README.md
@@ -68,6 +68,30 @@ Type: `bool`
 
 Default: `false`
 
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for azapi resources.
+
+Type:
+
+```hcl
+object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+```
+
+Default:
+
+```json
+{
+  "error_message_regex": [
+    "Cannot modify this site because another operation is in progress"
+  ]
+}
+```
+
 ## Outputs
 
 The following outputs are exported:

--- a/modules/config_azurestorageaccounts/main.tf
+++ b/modules/config_azurestorageaccounts/main.tf
@@ -6,4 +6,5 @@ resource "azapi_resource_action" "this" {
   body = {
     properties = local.storage_mounts
   }
+  retry = var.retry
 }

--- a/modules/config_azurestorageaccounts/variables.tf
+++ b/modules/config_azurestorageaccounts/variables.tf
@@ -39,3 +39,15 @@ variable "is_slot" {
   default     = false
   description = "Whether the parent resource is a deployment slot. Defaults to `false`."
 }
+
+variable "retry" {
+  type = object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+  default = {
+    error_message_regex = ["Cannot modify this site because another operation is in progress"]
+  }
+  description = "Retry configuration for azapi resources."
+}

--- a/modules/config_backup/README.md
+++ b/modules/config_backup/README.md
@@ -52,6 +52,30 @@ Type: `bool`
 
 Default: `true`
 
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for azapi resources.
+
+Type:
+
+```hcl
+object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+```
+
+Default:
+
+```json
+{
+  "error_message_regex": [
+    "Cannot modify this site because another operation is in progress"
+  ]
+}
+```
+
 ### <a name="input_schedule"></a> [schedule](#input\_schedule)
 
 Description: The backup schedule configuration.

--- a/modules/config_backup/main.tf
+++ b/modules/config_backup/main.tf
@@ -17,4 +17,5 @@ resource "azapi_update_resource" "this" {
     }
   }
   response_export_values = []
+  retry                  = var.retry
 }

--- a/modules/config_backup/variables.tf
+++ b/modules/config_backup/variables.tf
@@ -21,6 +21,18 @@ variable "enabled" {
   description = "Is backup enabled? Defaults to `true`."
 }
 
+variable "retry" {
+  type = object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+  default = {
+    error_message_regex = ["Cannot modify this site because another operation is in progress"]
+  }
+  description = "Retry configuration for azapi resources."
+}
+
 variable "schedule" {
   type = object({
     frequency_interval       = optional(number)

--- a/modules/config_connectionstrings/README.md
+++ b/modules/config_connectionstrings/README.md
@@ -62,6 +62,30 @@ Type: `bool`
 
 Default: `false`
 
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for azapi resources.
+
+Type:
+
+```hcl
+object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+```
+
+Default:
+
+```json
+{
+  "error_message_regex": [
+    "Cannot modify this site because another operation is in progress"
+  ]
+}
+```
+
 ## Outputs
 
 The following outputs are exported:

--- a/modules/config_connectionstrings/main.tf
+++ b/modules/config_connectionstrings/main.tf
@@ -9,4 +9,5 @@ resource "azapi_update_resource" "this" {
     } }
   }
   response_export_values = []
+  retry                  = var.retry
 }

--- a/modules/config_connectionstrings/variables.tf
+++ b/modules/config_connectionstrings/variables.tf
@@ -33,3 +33,15 @@ variable "is_slot" {
   default     = false
   description = "Whether the parent resource is a deployment slot. Defaults to `false`."
 }
+
+variable "retry" {
+  type = object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+  default = {
+    error_message_regex = ["Cannot modify this site because another operation is in progress"]
+  }
+  description = "Retry configuration for azapi resources."
+}

--- a/modules/config_logs/README.md
+++ b/modules/config_logs/README.md
@@ -108,6 +108,30 @@ object({
 
 Default: `null`
 
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for azapi resources.
+
+Type:
+
+```hcl
+object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+```
+
+Default:
+
+```json
+{
+  "error_message_regex": [
+    "Cannot modify this site because another operation is in progress"
+  ]
+}
+```
+
 ## Outputs
 
 The following outputs are exported:

--- a/modules/config_logs/main.tf
+++ b/modules/config_logs/main.tf
@@ -48,4 +48,5 @@ resource "azapi_update_resource" "this" {
     )
   }
   response_export_values = []
+  retry                  = var.retry
 }

--- a/modules/config_logs/variables.tf
+++ b/modules/config_logs/variables.tf
@@ -68,3 +68,15 @@ HTTP log settings.
   - `retention_in_mb` - (Required) The maximum size in MB before being rotated.
 DESCRIPTION
 }
+
+variable "retry" {
+  type = object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+  default = {
+    error_message_regex = ["Cannot modify this site because another operation is in progress"]
+  }
+  description = "Retry configuration for azapi resources."
+}

--- a/modules/config_metadata/README.md
+++ b/modules/config_metadata/README.md
@@ -50,6 +50,30 @@ Type: `bool`
 
 Default: `false`
 
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for azapi resources.
+
+Type:
+
+```hcl
+object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+```
+
+Default:
+
+```json
+{
+  "error_message_regex": [
+    "Cannot modify this site because another operation is in progress"
+  ]
+}
+```
+
 ## Outputs
 
 The following outputs are exported:

--- a/modules/config_metadata/main.tf
+++ b/modules/config_metadata/main.tf
@@ -5,4 +5,5 @@ resource "azapi_resource_action" "this" {
   body = {
     properties = var.metadata
   }
+  retry = var.retry
 }

--- a/modules/config_metadata/variables.tf
+++ b/modules/config_metadata/variables.tf
@@ -23,3 +23,15 @@ variable "is_slot" {
   default     = false
   description = "Whether the parent resource is a deployment slot. Defaults to `false`."
 }
+
+variable "retry" {
+  type = object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+  default = {
+    error_message_regex = ["Cannot modify this site because another operation is in progress"]
+  }
+  description = "Retry configuration for azapi resources."
+}

--- a/modules/config_slotconfignames/README.md
+++ b/modules/config_slotconfignames/README.md
@@ -52,6 +52,30 @@ Type: `list(string)`
 
 Default: `[]`
 
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for azapi resources.
+
+Type:
+
+```hcl
+object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+```
+
+Default:
+
+```json
+{
+  "error_message_regex": [
+    "Cannot modify this site because another operation is in progress"
+  ]
+}
+```
+
 ## Outputs
 
 The following outputs are exported:

--- a/modules/config_slotconfignames/main.tf
+++ b/modules/config_slotconfignames/main.tf
@@ -9,4 +9,5 @@ resource "azapi_update_resource" "this" {
     }
   }
   response_export_values = []
+  retry                  = var.retry
 }

--- a/modules/config_slotconfignames/variables.tf
+++ b/modules/config_slotconfignames/variables.tf
@@ -20,3 +20,15 @@ variable "connection_string_names" {
   default     = []
   description = "A list of connection string names that should be sticky (not swapped during slot swaps)."
 }
+
+variable "retry" {
+  type = object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+  default = {
+    error_message_regex = ["Cannot modify this site because another operation is in progress"]
+  }
+  description = "Retry configuration for azapi resources."
+}

--- a/modules/extensions_zipdeploy/README.md
+++ b/modules/extensions_zipdeploy/README.md
@@ -50,6 +50,30 @@ Type: `bool`
 
 Default: `false`
 
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for azapi resources.
+
+Type:
+
+```hcl
+object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+```
+
+Default:
+
+```json
+{
+  "error_message_regex": [
+    "Cannot modify this site because another operation is in progress"
+  ]
+}
+```
+
 ## Outputs
 
 The following outputs are exported:

--- a/modules/extensions_zipdeploy/main.tf
+++ b/modules/extensions_zipdeploy/main.tf
@@ -9,6 +9,7 @@ resource "azapi_resource_action" "this" {
       type       = "zip"
     }
   }
+  retry = var.retry
 
   lifecycle {
     ignore_changes = [body]

--- a/modules/extensions_zipdeploy/variables.tf
+++ b/modules/extensions_zipdeploy/variables.tf
@@ -23,3 +23,15 @@ variable "is_slot" {
   default     = false
   description = "Whether the parent resource is a deployment slot. Defaults to `false`."
 }
+
+variable "retry" {
+  type = object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+  default = {
+    error_message_regex = ["Cannot modify this site because another operation is in progress"]
+  }
+  description = "Retry configuration for azapi resources."
+}

--- a/modules/hostname_binding/README.md
+++ b/modules/hostname_binding/README.md
@@ -42,6 +42,30 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for azapi resources.
+
+Type:
+
+```hcl
+object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+```
+
+Default:
+
+```json
+{
+  "error_message_regex": [
+    "Cannot modify this site because another operation is in progress"
+  ]
+}
+```
+
 ### <a name="input_ssl_state"></a> [ssl\_state](#input\_ssl\_state)
 
 Description: The SSL state for the hostname binding. Possible values include `Disabled`, `IpBasedEnabled`, `SniEnabled`.

--- a/modules/hostname_binding/main.tf
+++ b/modules/hostname_binding/main.tf
@@ -9,4 +9,5 @@ resource "azapi_resource" "this" {
     }
   }
   response_export_values = []
+  retry                  = var.retry
 }

--- a/modules/hostname_binding/variables.tf
+++ b/modules/hostname_binding/variables.tf
@@ -18,6 +18,18 @@ variable "parent_id" {
   }
 }
 
+variable "retry" {
+  type = object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+  default = {
+    error_message_regex = ["Cannot modify this site because another operation is in progress"]
+  }
+  description = "Retry configuration for azapi resources."
+}
+
 variable "ssl_state" {
   type        = string
   default     = null

--- a/modules/publishing_credential_policy/README.md
+++ b/modules/publishing_credential_policy/README.md
@@ -58,6 +58,30 @@ Type: `bool`
 
 Default: `false`
 
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for azapi resources.
+
+Type:
+
+```hcl
+object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+```
+
+Default:
+
+```json
+{
+  "error_message_regex": [
+    "Cannot modify this site because another operation is in progress"
+  ]
+}
+```
+
 ## Outputs
 
 The following outputs are exported:

--- a/modules/publishing_credential_policy/main.tf
+++ b/modules/publishing_credential_policy/main.tf
@@ -8,4 +8,5 @@ resource "azapi_update_resource" "this" {
     }
   }
   response_export_values = []
+  retry                  = var.retry
 }

--- a/modules/publishing_credential_policy/variables.tf
+++ b/modules/publishing_credential_policy/variables.tf
@@ -34,3 +34,15 @@ variable "is_slot" {
   default     = false
   description = "Whether the parent resource is a deployment slot. Defaults to `false`."
 }
+
+variable "retry" {
+  type = object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+  default = {
+    error_message_regex = ["Cannot modify this site because another operation is in progress"]
+  }
+  description = "Retry configuration for azapi resources."
+}

--- a/modules/slot/README.md
+++ b/modules/slot/README.md
@@ -439,6 +439,30 @@ object({
 
 Default: `null`
 
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for azapi resources.
+
+Type:
+
+```hcl
+object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+```
+
+Default:
+
+```json
+{
+  "error_message_regex": [
+    "Cannot modify this site because another operation is in progress"
+  ]
+}
+```
+
 ### <a name="input_role_assignments"></a> [role\_assignments](#input\_role\_assignments)
 
 Description: Role assignments for the slot.

--- a/modules/slot/main.interfaces.tf
+++ b/modules/slot/main.interfaces.tf
@@ -29,6 +29,7 @@ resource "azapi_resource" "lock" {
   type                   = each.value.type
   body                   = each.value.body
   response_export_values = []
+  retry                  = var.retry
 }
 
 resource "azapi_resource" "role_assignment" {
@@ -40,6 +41,7 @@ resource "azapi_resource" "role_assignment" {
   body                   = each.value.body
   ignore_null_property   = true
   response_export_values = []
+  retry                  = var.retry
 }
 
 resource "azapi_resource" "private_endpoint" {
@@ -51,6 +53,7 @@ resource "azapi_resource" "private_endpoint" {
   type                   = each.value.type
   body                   = each.value.body
   response_export_values = []
+  retry                  = var.retry
   tags                   = each.value.tags
 }
 
@@ -62,6 +65,7 @@ resource "azapi_resource" "private_dns_zone_group" {
   type                   = each.value.type
   body                   = each.value.body
   response_export_values = []
+  retry                  = var.retry
 }
 
 resource "azapi_resource" "lock_private_endpoint" {
@@ -72,6 +76,7 @@ resource "azapi_resource" "lock_private_endpoint" {
   type                   = each.value.type
   body                   = each.value.body
   response_export_values = []
+  retry                  = var.retry
 }
 
 resource "azapi_resource" "role_assignment_private_endpoint" {

--- a/modules/slot/main.tf
+++ b/modules/slot/main.tf
@@ -146,7 +146,8 @@ resource "azapi_resource" "this" {
   response_export_values = [
     "identity.principalId",
   ]
-  tags = var.tags
+  retry = var.retry
+  tags  = var.tags
 
   dynamic "identity" {
     for_each = module.site_config_helpers.has_identity ? [module.site_config_helpers.identity_block] : []
@@ -165,6 +166,7 @@ module "config_appsettings" {
   app_settings = local.merged_app_settings
   parent_id    = azapi_resource.this.id
   is_slot      = true
+  retry        = var.retry
 }
 
 # Slot connection strings
@@ -174,6 +176,7 @@ module "config_connectionstrings" {
   connection_strings = var.connection_strings
   parent_id          = azapi_resource.this.id
   is_slot            = true
+  retry              = var.retry
 }
 
 # Slot storage account mounts
@@ -185,6 +188,7 @@ module "config_azurestorageaccounts" {
     access_key = var.storage_shares_access_keys[k]
   }) }
   is_slot = true
+  retry   = var.retry
 }
 
 # Slot FTP publishing credential policy
@@ -196,6 +200,7 @@ module "ftp_publishing_credential_policy" {
   parent_id = azapi_resource.this.id
   allow     = false
   is_slot   = true
+  retry     = var.retry
 }
 
 # Slot metadata
@@ -205,6 +210,7 @@ module "config_metadata" {
   metadata  = { for m in coalesce(module.site_config_helpers.site_config_metadata, []) : m.name => m.value }
   parent_id = azapi_resource.this.id
   is_slot   = true
+  retry     = var.retry
 }
 
 # Slot SCM publishing credential policy
@@ -216,6 +222,7 @@ module "scm_publishing_credential_policy" {
   parent_id = azapi_resource.this.id
   allow     = false
   is_slot   = true
+  retry     = var.retry
 }
 
 # Slot zip deploy
@@ -241,6 +248,7 @@ module "extensions_zipdeploy" {
   parent_id       = azapi_resource.this.id
   zip_deploy_file = var.zip_deploy_file
   is_slot         = true
+  retry           = var.retry
 
   depends_on = [
     time_sleep.wait_before_zip_deploy,

--- a/modules/slot/variables.tf
+++ b/modules/slot/variables.tf
@@ -315,6 +315,18 @@ variable "resource_config" {
   description = "Resource config for Container App environment hosted apps."
 }
 
+variable "retry" {
+  type = object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+  default = {
+    error_message_regex = ["Cannot modify this site because another operation is in progress"]
+  }
+  description = "Retry configuration for azapi resources."
+}
+
 variable "role_assignments" {
   type = map(object({
     role_definition_id_or_name             = string

--- a/variables.tf
+++ b/variables.tf
@@ -1499,6 +1499,24 @@ variable "resource_config" {
 DESCRIPTION
 }
 
+variable "retry" {
+  type = object({
+    error_message_regex = list(string)
+    interval_seconds    = optional(number, 10)
+    max_retries         = optional(number, 3)
+  })
+  default = {
+    error_message_regex = ["Cannot modify this site because another operation is in progress"]
+  }
+  description = <<-EOT
+Retry configuration for all azapi resources. Defaults to retrying on 409 Conflict errors caused by concurrent operations.
+
+- `error_message_regex` - (Required) A list of regular expressions to match against error messages. If any match, the operation will be retried.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries. Defaults to `10`.
+- `max_retries` - (Optional) The maximum number of retries. Defaults to `3`.
+EOT
+}
+
 variable "role_assignments" {
   type = map(object({
     role_definition_id_or_name             = string


### PR DESCRIPTION
## Description

Adds a configurable `retry` variable that is passed to all `azapi_resource`, `azapi_update_resource`, and `azapi_resource_action` resources across the root module, slot submodule, and all config submodules.

## Default Behavior

The default retries on **409 Conflict** errors caused by concurrent operations with:
- **Regex**: `Cannot modify this site because another operation is in progress`
- **Interval**: 10 seconds between retries
- **Max retries**: 3 attempts

This addresses the common error:
\\\
RESPONSE 409: 409 Conflict
Cannot modify this site because another operation is in progress.
\\\

## Changes

- Added `var.retry` to root module `variables.tf`
- Added `retry = var.retry` to every azapi resource in the root module and all submodules
- Passed `retry` through all module calls (config, auth, backup, logs, deploy, custom domains, slot)