### PR TITLE
fix: stop certificate and hostname binding submodules proposing null removals

### DIFF
--- a/modules/certificate/main.tf
+++ b/modules/certificate/main.tf
@@ -13,6 +13,7 @@ resource "azapi_resource" "this" {
       hostNames          = var.host_names
     }
   }
+  ignore_null_property = true
   response_export_values = [
     "properties.thumbprint",
     "properties.expirationDate",

--- a/modules/certificate/outputs.tf
+++ b/modules/certificate/outputs.tf
@@ -36,5 +36,5 @@ output "subject_name" {
 
 output "thumbprint" {
   description = "The thumbprint of the certificate. Pass this value into `custom_domains[*].thumbprint` to bind the certificate to a hostname."
-  value       = azapi_resource.this.output.properties.thumbprint
+  value       = try(azapi_resource.this.output.properties.thumbprint, null)
 }

--- a/modules/certificate/tests/unit/host_names.tftest.hcl
+++ b/modules/certificate/tests/unit/host_names.tftest.hcl
@@ -13,7 +13,25 @@
 // the attribute that opts us into that behaviour must stay set, and the
 // variable must reach the body unchanged whether or not the caller supplies it.
 
-mock_provider "azapi" {}
+// Under `command = apply` the module's outputs are evaluated, and
+// `output "thumbprint"` dereferences `azapi_resource.this.output` without a
+// `try()`. A bare mock returns null there, so the resource needs defaults that
+// stand in for what Azure echoes back on read.
+mock_provider "azapi" {
+  mock_resource "azapi_resource" {
+    defaults = {
+      output = {
+        properties = {
+          thumbprint           = "ABCDEF0123456789ABCDEF0123456789ABCDEF01"
+          expirationDate       = "2027-01-01T00:00:00Z"
+          subjectName          = "app.contoso.com"
+          issuer               = "Test CA"
+          keyVaultSecretStatus = "Succeeded"
+        }
+      }
+    }
+  }
+}
 
 variables {
   location       = "eastus"
@@ -24,7 +42,7 @@ variables {
 }
 
 run "host_names_omitted" {
-  command = plan
+  command = apply
 
   assert {
     condition     = azapi_resource.this.ignore_null_property == true
@@ -38,7 +56,7 @@ run "host_names_omitted" {
 }
 
 run "host_names_explicit" {
-  command = plan
+  command = apply
 
   variables {
     host_names = ["app.contoso.com", "www.contoso.com"]

--- a/modules/certificate/tests/unit/host_names.tftest.hcl
+++ b/modules/certificate/tests/unit/host_names.tftest.hcl
@@ -1,0 +1,59 @@
+// Regression coverage for #284: with `host_names` omitted, every plan proposed
+// removing the host names Azure had derived from the certificate's subject
+// alternative names.
+//
+// A note on what these assertions can and cannot reach. `ignore_null_property`
+// is applied by the azapi provider when it serialises the request body, and
+// `mock_provider` never gets that far — under a mock, `body.properties` still
+// carries `hostNames = null`. So there is no way from here to assert "the key
+// is absent from the outgoing request"; that is the provider's own behaviour
+// and is covered by the provider's tests, not ours.
+//
+// What we can pin is the part we own, which is where the bug actually lived:
+// the attribute that opts us into that behaviour must stay set, and the
+// variable must reach the body unchanged whether or not the caller supplies it.
+
+mock_provider "azapi" {}
+
+variables {
+  location       = "eastus"
+  name           = "test-certificate"
+  parent_id      = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg"
+  server_farm_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Web/serverfarms/test-plan"
+  pfx_blob       = "dGVzdC1wZng="
+}
+
+run "host_names_omitted" {
+  command = plan
+
+  assert {
+    condition     = azapi_resource.this.ignore_null_property == true
+    error_message = "`ignore_null_property` must stay enabled. Without it the null `hostNames` is sent to Azure, which returns the derived host names on the next read, and every plan proposes removing them (#284)."
+  }
+
+  assert {
+    condition     = try(nonsensitive(azapi_resource.this.body.properties.hostNames) == null, false)
+    error_message = "With `host_names` omitted the module must leave `hostNames` null and let Azure derive it, rather than substituting a default."
+  }
+}
+
+run "host_names_explicit" {
+  command = plan
+
+  variables {
+    host_names = ["app.contoso.com", "www.contoso.com"]
+  }
+
+  assert {
+    condition     = azapi_resource.this.ignore_null_property == true
+    error_message = "`ignore_null_property` must stay enabled regardless of whether `host_names` is supplied."
+  }
+
+  // `ignore_null_property` only skips nulls, so a caller-supplied list is still
+  // sent and still diffs normally. This is the property that makes it the right
+  // fix instead of `ignore_body_changes`, which would mask drift here too.
+  assert {
+    condition     = try(join(",", tolist(nonsensitive(azapi_resource.this.body.properties.hostNames))) == "app.contoso.com,www.contoso.com", false)
+    error_message = "An explicit `host_names` list must reach the request body unchanged, so user-managed host names keep being reconciled."
+  }
+}

--- a/modules/certificate/tests/unit/host_names.tftest.hcl
+++ b/modules/certificate/tests/unit/host_names.tftest.hcl
@@ -13,25 +13,7 @@
 // the attribute that opts us into that behaviour must stay set, and the
 // variable must reach the body unchanged whether or not the caller supplies it.
 
-// Under `command = apply` the module's outputs are evaluated, and
-// `output "thumbprint"` dereferences `azapi_resource.this.output` without a
-// `try()`. A bare mock returns null there, so the resource needs defaults that
-// stand in for what Azure echoes back on read.
-mock_provider "azapi" {
-  mock_resource "azapi_resource" {
-    defaults = {
-      output = {
-        properties = {
-          thumbprint           = "ABCDEF0123456789ABCDEF0123456789ABCDEF01"
-          expirationDate       = "2027-01-01T00:00:00Z"
-          subjectName          = "app.contoso.com"
-          issuer               = "Test CA"
-          keyVaultSecretStatus = "Succeeded"
-        }
-      }
-    }
-  }
-}
+mock_provider "azapi" {}
 
 variables {
   location       = "eastus"

--- a/modules/hostname_binding/main.tf
+++ b/modules/hostname_binding/main.tf
@@ -8,6 +8,7 @@ resource "azapi_resource" "this" {
       thumbprint = var.thumbprint
     }
   }
+  ignore_null_property   = true
   response_export_values = []
   retry                  = var.retry
 }

--- a/modules/hostname_binding/tests/unit/null_properties.tftest.hcl
+++ b/modules/hostname_binding/tests/unit/null_properties.tftest.hcl
@@ -16,7 +16,7 @@ variables {
 }
 
 run "optional_properties_omitted" {
-  command = plan
+  command = apply
 
   assert {
     condition     = azapi_resource.this.ignore_null_property == true
@@ -35,7 +35,7 @@ run "optional_properties_omitted" {
 }
 
 run "optional_properties_explicit" {
-  command = plan
+  command = apply
 
   variables {
     ssl_state  = "SniEnabled"

--- a/modules/hostname_binding/tests/unit/null_properties.tftest.hcl
+++ b/modules/hostname_binding/tests/unit/null_properties.tftest.hcl
@@ -1,0 +1,61 @@
+// Companion coverage to `modules/certificate` for the same bug found while
+// auditing #284. `ssl_state` and `thumbprint` are both optional and both
+// server-defaulted — Azure returns `sslState: "Disabled"` when you don't set
+// it — so sending them as explicit nulls produced the same perpetual diff.
+//
+// As in the certificate test, `mock_provider` does not run the azapi
+// provider's serialisation, so these assertions pin the attribute that opts us
+// into the null-stripping plus the variable-to-body wiring, not the provider's
+// own behaviour.
+
+mock_provider "azapi" {}
+
+variables {
+  hostname  = "app.contoso.com"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Web/sites/test-site"
+}
+
+run "optional_properties_omitted" {
+  command = plan
+
+  assert {
+    condition     = azapi_resource.this.ignore_null_property == true
+    error_message = "`ignore_null_property` must stay enabled. Azure defaults and returns `sslState`, so sending a null for it makes every subsequent plan propose removing the server-side value."
+  }
+
+  assert {
+    condition     = try(nonsensitive(azapi_resource.this.body.properties.sslState) == null, false)
+    error_message = "With `ssl_state` omitted the module must leave `sslState` null rather than picking a default on the caller's behalf."
+  }
+
+  assert {
+    condition     = try(nonsensitive(azapi_resource.this.body.properties.thumbprint) == null, false)
+    error_message = "With `thumbprint` omitted the module must leave `thumbprint` null."
+  }
+}
+
+run "optional_properties_explicit" {
+  command = plan
+
+  variables {
+    ssl_state  = "SniEnabled"
+    thumbprint = "ABCDEF0123456789ABCDEF0123456789ABCDEF01"
+  }
+
+  assert {
+    condition     = azapi_resource.this.ignore_null_property == true
+    error_message = "`ignore_null_property` must stay enabled regardless of which optional properties are supplied."
+  }
+
+  // Only nulls are skipped, so caller-supplied values still reach Azure and
+  // still diff normally.
+  assert {
+    condition     = try(nonsensitive(azapi_resource.this.body.properties.sslState) == "SniEnabled", false)
+    error_message = "An explicit `ssl_state` must reach the request body unchanged."
+  }
+
+  assert {
+    condition     = try(nonsensitive(azapi_resource.this.body.properties.thumbprint) == "ABCDEF0123456789ABCDEF0123456789ABCDEF01", false)
+    error_message = "An explicit `thumbprint` must reach the request body unchanged, otherwise the certificate binding silently stops being reconciled."
+  }
+}


### PR DESCRIPTION
Fixes #284

> [!IMPORTANT]
> **The E2E matrix does not cover this fix.** The only example that exercises the reported path — `examples/custom_domain/` — is marked `.e2eignore` because it binds `app.contoso.com`, a domain we don't own, so CI never deploys it. Verification here comes from the unit tests added below, not from a live deployment.

## What was happening

`Microsoft.Web/certificates` derives `hostNames` from the certificate's subject alternative names when you don't supply them. `modules/certificate` sent `hostNames: null` in the body anyway, Azure returned the derived list on the next GET, and `azapi` diffed that against the declared `null` — so every plan proposed removing the host names. The resource is unaffected in the portal; the plan just never comes back clean.

## Why `ignore_null_property` and not `ignore_body_changes`

I read the provider docs for both rather than assuming. `ignore_null_property` drops null-valued properties from the request body *and* suppresses the resulting diff, which is precisely the "the caller omitted this, let the server decide" case.

`ignore_body_changes` would be wrong here: it masks drift on `hostNames` unconditionally, including when a caller *does* set the list explicitly, and it has to be threaded through a variable per AVM's `ignore_body_changes` shape.

The concern raised was whether `ignore_null_property` is sufficient given `hostNames` is both user-settable and server-derived. It is, because the provider only skips *null* values. An explicit `host_names` list is still sent and still diffed normally, so user-managed host names keep working. The one behavioural tradeoff: going from an explicit list back to `null` no longer pushes a removal to Azure. That matches how the variable is already documented ("if omitted, Azure derives them"), and it's the same tradeoff the root `azapi_resource.this` already accepts.

## Audit of the other submodules

I checked every AzAPI resource under `modules/`. Two things narrow the field:

- `azapi_update_resource` **does not support** `ignore_null_property` — it isn't in that resource's schema. So `config_appsettings`, `config_authsettings`, `config_authsettingsv2`, `config_backup`, `config_connectionstrings`, `config_logs`, `config_slotconfignames`, and `publishing_credential_policy` can't take this fix even in principle. `ignore_missing_property` defaults to `true` there, which covers the common case.
- `azapi_resource_action` likewise has no such attribute, ruling out `config_azurestorageaccounts`, `config_metadata`, and `extensions_zipdeploy`. `extensions_zipdeploy` already carries `lifecycle { ignore_changes = [body] }` anyway.

That leaves the `azapi_resource` declarations:

| Resource | Status |
| --- | --- |
| `modules/certificate` `this` | **Fixed here** — the reported bug |
| `modules/hostname_binding` `this` | **Fixed here** — same shape, see below |
| `modules/slot` `this` | Already had it (line 145) |
| `modules/slot` `role_assignment` | Already had it |
| `modules/slot` `lock`, `private_endpoint`, `private_dns_zone_group`, `lock_private_endpoint`, `role_assignment_private_endpoint` | **Not touched — see below** |

`modules/hostname_binding` is the clear-cut second case: `ssl_state` and `thumbprint` are both optional variables that land directly in the body, and Azure defaults `sslState` to `Disabled` and returns it. Same failure mode, same fix.

### What I deliberately left alone

The remaining `azapi_resource` declarations in `modules/slot/main.interfaces.tf` build their bodies from `Azure/avm-utl-interfaces` outputs, not from local optional variables. Their sibling declarations in the root `main.interfaces.tf` have the identical gap — `role_assignment` and `diagnostic_setting` set `ignore_null_property`, the locks, private endpoints, and DNS zone groups don't. So it's a real inconsistency, but it spans root and slot together, and whether those utility-module bodies actually emit nulls depends on the utility module's behaviour rather than on anything in this repo. Fixing it blind alongside a certificate bugfix felt like the wrong bundle, so I've kept it out of this PR. It's written up separately with the full reasoning, pending its own triage.

## Example coverage

`examples/custom_domain/` already exercises the exact reported path: it declares `certificates.primary` with only `key_vault_id` and `key_vault_secret_name`, so `host_names` is omitted. Nothing to extend.

But as flagged at the top, that directory is `.e2eignore`'d — it binds `app.contoso.com`, which we don't own — so CI won't catch a regression here through a live deployment. Closing that gap needs an example built on a domain we control, which is a broader problem than this fix.

## Validation

Unit tests, under `modules/certificate/tests/unit/` and `modules/hostname_binding/tests/unit/` so the AVM suite picks each up as its own target. Both use `command = apply` with a mocked azapi provider, and each module gets an omitted case and an explicit case.

**What these can and can't reach.** `ignore_null_property` is applied by the azapi provider when it serialises the request body, and `mock_provider` never gets that far — under a mock, `body.properties` still carries `hostNames = null`. I probed for this directly rather than assuming it. So "assert the key is absent from the outgoing request" isn't reachable from a mocked run; that's the provider's behaviour and the provider's own tests own it.

What they do pin is the part we own, which is where the bug lived: the attribute that opts us into that behaviour stays enabled, and the variable reaches the body unchanged whether or not the caller supplies it. The explicit case is the one carrying weight for the argument above — `ignore_null_property` skips only nulls, so a caller-supplied list is still sent and still reconciled. That was reasoning; now it fails a test if it stops being true.

**Mutation-tested.** In a throwaway worktree I removed both `ignore_null_property` lines and re-ran. All four runs fail, each on the `ignore_null_property` assertion specifically rather than on incidental breakage, and all four pass again once restored. These tests demonstrably detect the thing they exist for.

## Incidental fix: `try()` on the certificate `thumbprint` output

Switching the tests to `apply` surfaced a separate, pre-existing defect, so this PR also carries a one-line fix to `modules/certificate/outputs.tf`. **This is distinct from #284** and is called out here so the changed outputs file doesn't look unexplained in a hostnames bugfix.

That file derives five values from `azapi_resource.this.output.properties`. Four of them — `expiration_date`, `issuer`, `key_vault_secret_status`, `subject_name` — wrap the lookup in `try(..., null)`. `thumbprint` alone did not.

It isn't a mock artefact. Against real Azure, any read where the thumbprint isn't populated yet fails the whole plan on output evaluation instead of returning null like its siblings. The obvious way to get there is a Key Vault secret that hasn't resolved — which is exactly what `key_vault_secret_status` exists to help diagnose, so the output meant to explain the failure is unreachable because a sibling has already blown up.

Consumers are unaffected by the null: `main.custom_domains.tf` feeds this into `hostname_binding`'s optional `thumbprint`, and with the `ignore_null_property` added above, a null is now dropped from the request rather than sent.

Fixing it also let the test's `mock_resource` defaults go away entirely — a bare `mock_provider "azapi" {}` now suffices. Those defaults had existed only to paper over this defect, which is the wrong shape for a test: it would have encoded the bug as expected behaviour and left the next reader unable to tell which mock entries were meaningful and which were compensating.

Also run:

- `terraform fmt -recursive -check` — clean.
- `terraform validate` — passes in `modules/certificate`, `modules/hostname_binding`, and the root module.
- No `apply` against real Azure and no live deployment locally; CI owns those.

If you're running the tests by hand, note that `terraform test` does not recurse into `tests/unit` — a bare invocation reports "Success! 0 passed, 0 failed" and exits 0, which looks like success and isn't. Pass `-test-directory=tests/unit`, which is what CI does.

_Drafted by Claude Opus 5._
