### PR TITLE
fix: correct Java linuxFxVersion strings for Linux sites

### DIFF
--- a/examples/application_stack/README.md
+++ b/examples/application_stack/README.md
@@ -176,6 +176,32 @@ module "avm_res_web_site" {
         }
       }
     }
+    slot3 = {
+      name                                           = "java-app-stack"
+      ftp_publish_basic_authentication_enabled       = false
+      webdeploy_publish_basic_authentication_enabled = false
+      site_config = {
+        application_stack = {
+          java = {
+            java_version = "21"
+          }
+        }
+      }
+    }
+    slot4 = {
+      name                                           = "tomcat-app-stack"
+      ftp_publish_basic_authentication_enabled       = false
+      webdeploy_publish_basic_authentication_enabled = false
+      site_config = {
+        application_stack = {
+          java = {
+            java_version           = "17"
+            java_container         = "TOMCAT"
+            java_container_version = "10.1"
+          }
+        }
+      }
+    }
   }
   enable_telemetry              = var.enable_telemetry
   kind                          = "webapp"

--- a/examples/application_stack/main.tf
+++ b/examples/application_stack/main.tf
@@ -165,6 +165,32 @@ module "avm_res_web_site" {
         }
       }
     }
+    slot3 = {
+      name                                           = "java-app-stack"
+      ftp_publish_basic_authentication_enabled       = false
+      webdeploy_publish_basic_authentication_enabled = false
+      site_config = {
+        application_stack = {
+          java = {
+            java_version = "21"
+          }
+        }
+      }
+    }
+    slot4 = {
+      name                                           = "tomcat-app-stack"
+      ftp_publish_basic_authentication_enabled       = false
+      webdeploy_publish_basic_authentication_enabled = false
+      site_config = {
+        application_stack = {
+          java = {
+            java_version           = "17"
+            java_container         = "TOMCAT"
+            java_container_version = "10.1"
+          }
+        }
+      }
+    }
   }
   enable_telemetry              = var.enable_telemetry
   kind                          = "webapp"

--- a/modules/site_config_helpers/main.tf
+++ b/modules/site_config_helpers/main.tf
@@ -114,6 +114,24 @@ locals {
     try(var.site_config.java_container_version, null),
     !local.is_linux && local.app_stack != null ? try(local.app_stack.java.java_container_version, null) : null,
   ), null)
+  # Azure expects Java linuxFxVersion strings shaped `<CONTAINER>|<container-version>-java<java-version>`,
+  # for example `JAVA|21-java21`, `TOMCAT|10.1-java17`, or `JBOSSEAP|7-java11`. Java 8 takes a `jre8`
+  # suffix instead, and a fully qualified three-part `JAVA` container version takes no suffix at all.
+  java_fx_container         = local.java_fx_stack == null ? null : upper(coalesce(try(local.java_fx_stack.java_container, null), "JAVA"))
+  java_fx_container_version = local.java_fx_stack == null ? null : try(coalesce(try(local.java_fx_stack.java_container_version, null), local.java_fx_major_version), null)
+  java_fx_major_version     = try(local.java_fx_stack.java_version, null)
+  java_fx_stack             = try(local.app_stack.java, null)
+  java_fx_suffix = (
+    local.java_fx_container_version == null || local.java_fx_major_version == null ? "" :
+    local.java_fx_major_version == "8" ? (
+      local.java_fx_container == "JAVA" ? (strcontains(local.java_fx_container_version, "u") ? "" : "-jre8") :
+      local.java_fx_container == "TOMCAT" ? (length(split(".", local.java_fx_container_version)) == 3 ? "-java8" : "-jre8") :
+      "-java8"
+    ) :
+    local.java_fx_container == "JAVA" && length(split(".", local.java_fx_container_version)) == 3 ? "" :
+    "-java${local.java_fx_major_version}"
+  )
+  java_fx_version = local.java_fx_container_version != null ? "${local.java_fx_container}|${local.java_fx_container_version}${local.java_fx_suffix}" : null
   java_version = try(coalesce(
     try(var.site_config.java_version, null),
     !local.is_linux && local.app_stack != null ? try(local.app_stack.java.java_version, null) : null,
@@ -125,7 +143,7 @@ locals {
       try(local.app_stack.python != null ? "PYTHON|${local.app_stack.python.python_version}" : null, null),
       try(local.app_stack.node != null ? "NODE|${local.app_stack.node.node_version}" : null, null),
       try(local.app_stack.dotnet != null ? "DOTNETCORE|${local.app_stack.dotnet.dotnet_version}" : null, null),
-      try(local.app_stack.java != null ? "JAVA|${local.app_stack.java.java_version}-${lower(coalesce(local.app_stack.java.java_container, "java"))}${local.app_stack.java.java_container_version != null ? "-${local.app_stack.java.java_container_version}" : ""}" : null, null),
+      local.java_fx_version,
       try(local.app_stack.powershell != null ? "POWERSHELL|${local.app_stack.powershell.powershell_version}" : null, null),
       try(local.app_stack.php != null ? "PHP|${local.app_stack.php.php_version}" : null, null),
     ), null) : null,

--- a/modules/site_config_helpers/tests/unit/linux_fx_version.tftest.hcl
+++ b/modules/site_config_helpers/tests/unit/linux_fx_version.tftest.hcl
@@ -1,0 +1,221 @@
+# Expected strings come from `az webapp list-runtimes --os linux`, which reports
+# configs such as `JAVA|11-java11`, `JAVA|8-jre8`, `TOMCAT|10.1-java11`, and
+# `JBOSSEAP|7-java11`.
+
+variables {
+  os_type = "Linux"
+}
+
+run "java_defaults_container_to_java" {
+  command = apply
+
+  variables {
+    site_config = {
+      application_stack = {
+        java = {
+          java_version = "21"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.linux_fx_version == "JAVA|21-java21"
+    error_message = "Expected `JAVA|21-java21`, got `${coalesce(output.linux_fx_version, "null")}`."
+  }
+}
+
+run "java_with_explicit_container" {
+  command = apply
+
+  variables {
+    site_config = {
+      application_stack = {
+        java = {
+          java_version           = "21"
+          java_container         = "JAVA"
+          java_container_version = "21"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.linux_fx_version == "JAVA|21-java21"
+    error_message = "Expected `JAVA|21-java21`, got `${coalesce(output.linux_fx_version, "null")}`."
+  }
+}
+
+run "java_fully_qualified_version_has_no_suffix" {
+  command = apply
+
+  variables {
+    site_config = {
+      application_stack = {
+        java = {
+          java_version           = "11"
+          java_container         = "JAVA"
+          java_container_version = "11.0.13"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.linux_fx_version == "JAVA|11.0.13"
+    error_message = "Expected `JAVA|11.0.13`, got `${coalesce(output.linux_fx_version, "null")}`."
+  }
+}
+
+run "java_8_uses_jre_suffix" {
+  command = apply
+
+  variables {
+    site_config = {
+      application_stack = {
+        java = {
+          java_version           = "8"
+          java_container         = "JAVA"
+          java_container_version = "8"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.linux_fx_version == "JAVA|8-jre8"
+    error_message = "Expected `JAVA|8-jre8`, got `${coalesce(output.linux_fx_version, "null")}`."
+  }
+}
+
+run "tomcat_puts_container_version_first" {
+  command = apply
+
+  variables {
+    site_config = {
+      application_stack = {
+        java = {
+          java_version           = "17"
+          java_container         = "TOMCAT"
+          java_container_version = "10.1"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.linux_fx_version == "TOMCAT|10.1-java17"
+    error_message = "Expected `TOMCAT|10.1-java17`, got `${coalesce(output.linux_fx_version, "null")}`."
+  }
+}
+
+run "tomcat_container_name_is_normalized" {
+  command = apply
+
+  variables {
+    site_config = {
+      application_stack = {
+        java = {
+          java_version           = "11"
+          java_container         = "tomcat"
+          java_container_version = "9.0"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.linux_fx_version == "TOMCAT|9.0-java11"
+    error_message = "Expected `TOMCAT|9.0-java11`, got `${coalesce(output.linux_fx_version, "null")}`."
+  }
+}
+
+run "tomcat_on_java_8_uses_jre_suffix" {
+  command = apply
+
+  variables {
+    site_config = {
+      application_stack = {
+        java = {
+          java_version           = "8"
+          java_container         = "TOMCAT"
+          java_container_version = "9.0"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.linux_fx_version == "TOMCAT|9.0-jre8"
+    error_message = "Expected `TOMCAT|9.0-jre8`, got `${coalesce(output.linux_fx_version, "null")}`."
+  }
+}
+
+run "tomcat_on_java_8_with_patch_version_uses_java_suffix" {
+  command = apply
+
+  variables {
+    site_config = {
+      application_stack = {
+        java = {
+          java_version           = "8"
+          java_container         = "TOMCAT"
+          java_container_version = "10.0.20"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.linux_fx_version == "TOMCAT|10.0.20-java8"
+    error_message = "Expected `TOMCAT|10.0.20-java8`, got `${coalesce(output.linux_fx_version, "null")}`."
+  }
+}
+
+run "jbosseap_puts_container_version_first" {
+  command = apply
+
+  variables {
+    site_config = {
+      application_stack = {
+        java = {
+          java_version           = "11"
+          java_container         = "JBOSSEAP"
+          java_container_version = "7"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.linux_fx_version == "JBOSSEAP|7-java11"
+    error_message = "Expected `JBOSSEAP|7-java11`, got `${coalesce(output.linux_fx_version, "null")}`."
+  }
+}
+
+run "windows_uses_dedicated_java_properties" {
+  command = apply
+
+  variables {
+    os_type = "Windows"
+    site_config = {
+      application_stack = {
+        java = {
+          java_version           = "17"
+          java_container         = "TOMCAT"
+          java_container_version = "10.1"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.linux_fx_version == null
+    error_message = "Windows sites should not set `linuxFxVersion`."
+  }
+
+  assert {
+    condition     = output.java_version == "17" && output.java_container == "TOMCAT" && output.java_container_version == "10.1"
+    error_message = "Windows sites should pass the Java properties through unchanged."
+  }
+}


### PR DESCRIPTION
Fixes #285

## The bug

We built the Java `linuxFxVersion` as `JAVA|<java-version>-<container>-<container-version>`. Azure wants `<CONTAINER>|<container-version>-java<java-version>`, so the expression was wrong in three separate ways:

| `application_stack.java` | Before | After (and what Azure stores) |
| --- | --- | --- |
| `java_version = "21"`, `java_container = "JAVA"`, `java_container_version = "21"` | `JAVA\|21-java-21` | `JAVA\|21-java21` |
| `java_version = "17"`, `java_container = "TOMCAT"`, `java_container_version = "10.1"` | `JAVA\|17-tomcat-10.1` | `TOMCAT\|10.1-java17` |
| `java_version = "11"`, `java_container = "JBOSSEAP"`, `java_container_version = "7"` | `JAVA\|11-jbosseap-7` | `JBOSSEAP\|7-java11` |
| `java_version = "8"`, `java_container = "JAVA"`, `java_container_version = "8"` | `JAVA\|8-java-8` | `JAVA\|8-jre8` |

The stray hyphen reported in #285 is the visible symptom, and it alone causes drift on every plan plus a wrong runtime stack in the portal. But the container cases were worse than the issue describes: the prefix was hardcoded to `JAVA|` and the two versions were in the wrong order, so **Tomcat and JBoss EAP never produced a valid string at all**.

## Source for the format

`az webapp list-runtimes --os linux` reports the accepted configs. The Java-family entries are:

```
JAVA|11-java11
JAVA|8-jre8
JBOSSEAP|8-java11
JBOSSEAP|7-java11
JBOSSEAP|7-java8
TOMCAT|11.0-java11
TOMCAT|10.1-java11
TOMCAT|9.0-java11
TOMCAT|9.0-jre8
```

So the shape is uniformly `<CONTAINER>|<container-version>-java<java-version>`, where the plain `JAVA` container repeats the Java version as its container version. Two edge cases fall out of that list and out of [`JavaLinuxFxStringBuilder`](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/appservice/helpers/fx_strings.go) in the AzureRM provider, which I mirrored:

- Java 8 takes a `jre8` suffix instead of `java8` — except for Tomcat with a three-part container version, which uses `-java8` (`TOMCAT|10.0.20-java8`).
- A fully qualified three-part `JAVA` container version takes no suffix at all (`JAVA|11.0.13`).

My local `az` (2.87.0) doesn't list Java 17/21/25 yet, but the provider handles them explicitly and the reporter's own Azure response in #285 confirms `JAVA|21-java21`.

## Changes

- `modules/site_config_helpers/main.tf` — rebuilt the Java branch of `linux_fx_version` as a few named locals instead of one dense inline expression. Container names are normalized with `upper()` so `tomcat` and `TOMCAT` both work.
- `modules/slot` shares this helper, so deployment slots pick up the fix without a separate change.
- `modules/site_config_helpers/tests/unit/linux_fx_version.tftest.hcl` — new unit tests covering every branch: the plain Java default, explicit containers, Tomcat, JBoss EAP, both Java 8 suffix rules, the fully qualified version case, container-name normalization, and the Windows path where `linuxFxVersion` stays null.
- `examples/application_stack` — added two slots, one plain Java 21 and one Tomcat 10.1 on Java 17, so CI exercises the fixed strings against real Azure. I added rather than rewrote, so the existing Python assertions are untouched.

Windows sites are unaffected. They use the dedicated `javaVersion`, `javaContainer`, and `javaContainerVersion` properties, which still pass through unchanged.

## Validation

`terraform fmt -recursive` is clean, `terraform validate` passes on the root module and the example, and the new unit tests pass 10/10. I did not run `terraform apply` locally; CI covers the real deployment.

_Drafted by Claude Opus 5._
