### PR TITLE
fix: validate conditionally required variables with clear messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1392,7 +1392,7 @@ Default: `null`
 
 ### <a name="input_fc1_runtime_name"></a> [fc1\_runtime\_name](#input\_fc1\_runtime\_name)
 
-Description: The Runtime of the Flex Consumption Function App. Possible values are `node`, `dotnet-isolated`, `powershell`, `python`, `java`.
+Description: The Runtime of the Flex Consumption Function App. Possible values are `node`, `dotnet-isolated`, `powershell`, `python`, `java`. Required when `function_app_uses_fc1` is `true`, otherwise ignored.
 
 Type: `string`
 
@@ -1400,7 +1400,7 @@ Default: `null`
 
 ### <a name="input_fc1_runtime_version"></a> [fc1\_runtime\_version](#input\_fc1\_runtime\_version)
 
-Description: The Runtime version of the Flex Consumption Function App.
+Description: The Runtime version of the Flex Consumption Function App. Required when `function_app_uses_fc1` is `true`, otherwise ignored.
 
 Type: `string`
 
@@ -1417,6 +1417,8 @@ Default: `false`
 ### <a name="input_function_app_uses_fc1"></a> [function\_app\_uses\_fc1](#input\_function\_app\_uses\_fc1)
 
 Description: Should this Function App run on a Flex Consumption Plan? Defaults to `false`.
+
+When `true`, these variables become required: `fc1_runtime_name`, `fc1_runtime_version`, `storage_authentication_type` and `storage_container_endpoint`. `storage_user_assigned_identity_id` is also required when `storage_authentication_type` is `UserAssignedIdentity`.
 
 Type: `bool`
 
@@ -2228,7 +2230,7 @@ Default: `{}`
 
 ### <a name="input_storage_account_access_key"></a> [storage\_account\_access\_key](#input\_storage\_account\_access\_key)
 
-Description: The access key of the Storage Account for the Function App.
+Description: The access key of the Storage Account for the Function App. Required when `kind` is `logicapp`.
 
 Type: `string`
 
@@ -2236,7 +2238,7 @@ Default: `null`
 
 ### <a name="input_storage_account_name"></a> [storage\_account\_name](#input\_storage\_account\_name)
 
-Description: The name of the Storage Account for the Function App.
+Description: The name of the Storage Account for the Function App. Required when `kind` is `logicapp`, and when `storage_uses_managed_identity` is `true`.
 
 Type: `string`
 
@@ -2260,7 +2262,7 @@ Default: `null`
 
 ### <a name="input_storage_authentication_type"></a> [storage\_authentication\_type](#input\_storage\_authentication\_type)
 
-Description: The authentication type for the backend storage account. Possible values are `StorageAccountConnectionString`, `SystemAssignedIdentity`, and `UserAssignedIdentity`.
+Description: The authentication type for the backend storage account. Possible values are `StorageAccountConnectionString`, `SystemAssignedIdentity`, and `UserAssignedIdentity`. Required when `function_app_uses_fc1` is `true`, otherwise ignored.
 
 Type: `string`
 
@@ -2268,7 +2270,7 @@ Default: `null`
 
 ### <a name="input_storage_container_endpoint"></a> [storage\_container\_endpoint](#input\_storage\_container\_endpoint)
 
-Description: The backend storage container endpoint for Flex Consumption Function Apps.
+Description: The backend storage container endpoint for Flex Consumption Function Apps. Required when `function_app_uses_fc1` is `true`, otherwise ignored.
 
 Type: `string`
 
@@ -2276,11 +2278,11 @@ Default: `null`
 
 ### <a name="input_storage_container_type"></a> [storage\_container\_type](#input\_storage\_container\_type)
 
-Description: The storage container type. The current supported type is `blobContainer`.
+Description: The storage container type used by Flex Consumption Function Apps. The only supported value today is `blobContainer`, which is the default. Ignored unless `function_app_uses_fc1` is `true`.
 
 Type: `string`
 
-Default: `null`
+Default: `"blobContainer"`
 
 ### <a name="input_storage_shares_to_mount"></a> [storage\_shares\_to\_mount](#input\_storage\_shares\_to\_mount)
 
@@ -2310,7 +2312,7 @@ Default: `{}`
 
 ### <a name="input_storage_user_assigned_identity_id"></a> [storage\_user\_assigned\_identity\_id](#input\_storage\_user\_assigned\_identity\_id)
 
-Description: The ID of the User Assigned Managed Identity for storage.
+Description: The ID of the User Assigned Managed Identity for storage. Required when `function_app_uses_fc1` is `true` and `storage_authentication_type` is `UserAssignedIdentity`.
 
 Type: `string`
 
@@ -2318,7 +2320,7 @@ Default: `null`
 
 ### <a name="input_storage_uses_managed_identity"></a> [storage\_uses\_managed\_identity](#input\_storage\_uses\_managed\_identity)
 
-Description: Should the Storage Account use a Managed Identity? Defaults to `false`.
+Description: Should the Function App's `AzureWebJobsStorage` app setting use a Managed Identity instead of a connection string? Defaults to `false`. This applies to non-Flex Consumption Function Apps; Flex Consumption apps use `storage_authentication_type` instead. Requires `storage_account_name` when `true`.
 
 Type: `bool`
 

--- a/tests/unit/conditionally_required_variables.tftest.hcl
+++ b/tests/unit/conditionally_required_variables.tftest.hcl
@@ -1,0 +1,172 @@
+mock_provider "azapi" {
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Web/sites/app-unit-test"
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {}
+mock_provider "time" {}
+
+variables {
+  location                 = "eastus"
+  name                     = "app-unit-test"
+  parent_id                = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+  service_plan_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Web/serverfarms/asp-test"
+  enable_telemetry         = false
+}
+
+run "flex_consumption_requires_runtime_name" {
+  command = plan
+
+  variables {
+    kind                        = "functionapp"
+    os_type                     = "Linux"
+    function_app_uses_fc1       = true
+    fc1_runtime_version         = "20"
+    storage_authentication_type = "SystemAssignedIdentity"
+    storage_container_endpoint  = "https://sttest.blob.core.windows.net/deployments"
+  }
+
+  expect_failures = [var.fc1_runtime_name]
+}
+
+run "flex_consumption_requires_runtime_version" {
+  command = plan
+
+  variables {
+    kind                        = "functionapp"
+    os_type                     = "Linux"
+    function_app_uses_fc1       = true
+    fc1_runtime_name            = "node"
+    storage_authentication_type = "SystemAssignedIdentity"
+    storage_container_endpoint  = "https://sttest.blob.core.windows.net/deployments"
+  }
+
+  expect_failures = [var.fc1_runtime_version]
+}
+
+run "flex_consumption_requires_storage_authentication_type" {
+  command = plan
+
+  variables {
+    kind                       = "functionapp"
+    os_type                    = "Linux"
+    function_app_uses_fc1      = true
+    fc1_runtime_name           = "node"
+    fc1_runtime_version        = "20"
+    storage_container_endpoint = "https://sttest.blob.core.windows.net/deployments"
+  }
+
+  expect_failures = [var.storage_authentication_type]
+}
+
+run "flex_consumption_requires_storage_container_endpoint" {
+  command = plan
+
+  variables {
+    kind                        = "functionapp"
+    os_type                     = "Linux"
+    function_app_uses_fc1       = true
+    fc1_runtime_name            = "node"
+    fc1_runtime_version         = "20"
+    storage_authentication_type = "SystemAssignedIdentity"
+  }
+
+  expect_failures = [var.storage_container_endpoint]
+}
+
+run "user_assigned_identity_authentication_requires_identity_id" {
+  command = plan
+
+  variables {
+    kind                        = "functionapp"
+    os_type                     = "Linux"
+    function_app_uses_fc1       = true
+    fc1_runtime_name            = "node"
+    fc1_runtime_version         = "20"
+    storage_authentication_type = "UserAssignedIdentity"
+    storage_container_endpoint  = "https://sttest.blob.core.windows.net/deployments"
+  }
+
+  expect_failures = [var.storage_user_assigned_identity_id]
+}
+
+run "logic_app_requires_storage_account_name" {
+  command = plan
+
+  variables {
+    kind                       = "logicapp"
+    os_type                    = "Windows"
+    storage_account_access_key = "not-a-real-key"
+  }
+
+  expect_failures = [var.storage_account_name]
+}
+
+run "logic_app_requires_storage_account_access_key" {
+  command = plan
+
+  variables {
+    kind                 = "logicapp"
+    os_type              = "Windows"
+    storage_account_name = "sttest"
+  }
+
+  expect_failures = [var.storage_account_access_key]
+}
+
+run "managed_identity_storage_requires_storage_account_name" {
+  command = plan
+
+  variables {
+    kind                          = "functionapp"
+    os_type                       = "Linux"
+    storage_uses_managed_identity = true
+  }
+
+  expect_failures = [var.storage_account_name]
+}
+
+run "unsupported_storage_container_type_is_rejected" {
+  command = plan
+
+  variables {
+    kind                   = "functionapp"
+    os_type                = "Linux"
+    function_app_uses_fc1  = false
+    storage_container_type = "fileShare"
+  }
+
+  expect_failures = [var.storage_container_type]
+}
+
+run "flex_consumption_defaults_storage_container_type" {
+  command = apply
+
+  variables {
+    kind                              = "functionapp"
+    os_type                           = "Linux"
+    function_app_uses_fc1             = true
+    fc1_runtime_name                  = "node"
+    fc1_runtime_version               = "20"
+    storage_authentication_type       = "UserAssignedIdentity"
+    storage_container_endpoint        = "https://sttest.blob.core.windows.net/deployments"
+    storage_user_assigned_identity_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/uai-test"
+  }
+
+  assert {
+    condition     = local.body.properties.functionAppConfig.deployment.storage.type == "blobcontainer"
+    error_message = "storage_container_type should default to blobContainer for Flex Consumption Function Apps."
+  }
+}
+
+run "web_app_ignores_flex_consumption_variables" {
+  command = apply
+
+  assert {
+    condition     = local.body.properties.functionAppConfig == null
+    error_message = "functionAppConfig should stay null when function_app_uses_fc1 is false."
+  }
+}

--- a/tests/unit/conditionally_required_variables.tftest.hcl
+++ b/tests/unit/conditionally_required_variables.tftest.hcl
@@ -1,3 +1,16 @@
+# Unit tests for the conditionally required variables described in issue #236.
+#
+# AVM guidance says unit tests should use `command = apply`, since mocked providers
+# make apply safe. The two runs that assert on `local.body` do exactly that.
+#
+# The nine `expect_failures` runs must use `command = plan` instead, and this is not
+# an oversight. Variable validation is evaluated during the plan stage, so a failure
+# there aborts the apply before it starts. Terraform then reports "Expected failure
+# while planning ... the apply operation could not be executed and so the overall
+# test case will be marked as a failure" and fails the run despite the failure being
+# the point of the test. That applies to any `expect_failures` on a variable, so
+# `plan` is the only command these can use.
+
 mock_provider "azapi" {
   mock_resource "azapi_resource" {
     defaults = {

--- a/variables.tf
+++ b/variables.tf
@@ -1207,13 +1207,27 @@ variable "end_to_end_encryption_enabled" {
 variable "fc1_runtime_name" {
   type        = string
   default     = null
-  description = "The Runtime of the Flex Consumption Function App. Possible values are `node`, `dotnet-isolated`, `powershell`, `python`, `java`."
+  description = "The Runtime of the Flex Consumption Function App. Possible values are `node`, `dotnet-isolated`, `powershell`, `python`, `java`. Required when `function_app_uses_fc1` is `true`, otherwise ignored."
+
+  validation {
+    condition     = var.function_app_uses_fc1 != true || var.fc1_runtime_name != null
+    error_message = "`fc1_runtime_name` is required when `function_app_uses_fc1` is `true`. Possible values are `node`, `dotnet-isolated`, `powershell`, `python` and `java`."
+  }
+  validation {
+    condition     = var.fc1_runtime_name == null || contains(["node", "dotnet-isolated", "powershell", "python", "java"], lower(coalesce(var.fc1_runtime_name, "node")))
+    error_message = "`fc1_runtime_name` must be one of `node`, `dotnet-isolated`, `powershell`, `python` or `java`."
+  }
 }
 
 variable "fc1_runtime_version" {
   type        = string
   default     = null
-  description = "The Runtime version of the Flex Consumption Function App."
+  description = "The Runtime version of the Flex Consumption Function App. Required when `function_app_uses_fc1` is `true`, otherwise ignored."
+
+  validation {
+    condition     = var.function_app_uses_fc1 != true || var.fc1_runtime_version != null
+    error_message = "`fc1_runtime_version` is required when `function_app_uses_fc1` is `true`. Set it to the language version your Flex Consumption Function App targets, for example `20` for `node`."
+  }
 }
 
 variable "ftp_publish_basic_authentication_enabled" {
@@ -1225,7 +1239,12 @@ variable "ftp_publish_basic_authentication_enabled" {
 variable "function_app_uses_fc1" {
   type        = bool
   default     = false
-  description = "Should this Function App run on a Flex Consumption Plan? Defaults to `false`."
+  description = <<DESCRIPTION
+Should this Function App run on a Flex Consumption Plan? Defaults to `false`.
+
+When `true`, these variables become required: `fc1_runtime_name`, `fc1_runtime_version`, `storage_authentication_type` and `storage_container_endpoint`. `storage_user_assigned_identity_id` is also required when `storage_authentication_type` is `UserAssignedIdentity`.
+DESCRIPTION
+  nullable    = false
 }
 
 variable "functions_extension_version" {
@@ -1993,14 +2012,28 @@ DESCRIPTION
 variable "storage_account_access_key" {
   type        = string
   default     = null
-  description = "The access key of the Storage Account for the Function App."
+  description = "The access key of the Storage Account for the Function App. Required when `kind` is `logicapp`."
   sensitive   = true
+
+  validation {
+    condition     = var.kind != "logicapp" || var.storage_account_access_key != null
+    error_message = "`storage_account_access_key` is required when `kind` is `logicapp`, because the Logic App runtime is configured with a Storage Account connection string."
+  }
 }
 
 variable "storage_account_name" {
   type        = string
   default     = null
-  description = "The name of the Storage Account for the Function App."
+  description = "The name of the Storage Account for the Function App. Required when `kind` is `logicapp`, and when `storage_uses_managed_identity` is `true`."
+
+  validation {
+    condition     = var.kind != "logicapp" || var.storage_account_name != null
+    error_message = "`storage_account_name` is required when `kind` is `logicapp`, because the Logic App runtime is configured with a Storage Account connection string."
+  }
+  validation {
+    condition     = var.storage_uses_managed_identity != true || var.storage_account_name != null
+    error_message = "`storage_account_name` is required when `storage_uses_managed_identity` is `true`, because it is used to set the `AzureWebJobsStorage__accountName` app setting."
+  }
 }
 
 variable "storage_account_required" {
@@ -2018,19 +2051,39 @@ variable "storage_account_share_name" {
 variable "storage_authentication_type" {
   type        = string
   default     = null
-  description = "The authentication type for the backend storage account. Possible values are `StorageAccountConnectionString`, `SystemAssignedIdentity`, and `UserAssignedIdentity`."
+  description = "The authentication type for the backend storage account. Possible values are `StorageAccountConnectionString`, `SystemAssignedIdentity`, and `UserAssignedIdentity`. Required when `function_app_uses_fc1` is `true`, otherwise ignored."
+
+  validation {
+    condition     = var.function_app_uses_fc1 != true || var.storage_authentication_type != null
+    error_message = "`storage_authentication_type` is required when `function_app_uses_fc1` is `true`. Possible values are `StorageAccountConnectionString`, `SystemAssignedIdentity` and `UserAssignedIdentity`."
+  }
+  validation {
+    condition     = var.storage_authentication_type == null || contains(["storageaccountconnectionstring", "systemassignedidentity", "userassignedidentity"], lower(coalesce(var.storage_authentication_type, "systemassignedidentity")))
+    error_message = "`storage_authentication_type` must be one of `StorageAccountConnectionString`, `SystemAssignedIdentity` or `UserAssignedIdentity`."
+  }
 }
 
 variable "storage_container_endpoint" {
   type        = string
   default     = null
-  description = "The backend storage container endpoint for Flex Consumption Function Apps."
+  description = "The backend storage container endpoint for Flex Consumption Function Apps. Required when `function_app_uses_fc1` is `true`, otherwise ignored."
+
+  validation {
+    condition     = var.function_app_uses_fc1 != true || var.storage_container_endpoint != null
+    error_message = "`storage_container_endpoint` is required when `function_app_uses_fc1` is `true`. Set it to the blob container that holds the deployment package."
+  }
 }
 
 variable "storage_container_type" {
   type        = string
-  default     = null
-  description = "The storage container type. The current supported type is `blobContainer`."
+  default     = "blobContainer"
+  description = "The storage container type used by Flex Consumption Function Apps. The only supported value today is `blobContainer`, which is the default. Ignored unless `function_app_uses_fc1` is `true`."
+  nullable    = false
+
+  validation {
+    condition     = lower(var.storage_container_type) == "blobcontainer"
+    error_message = "`storage_container_type` must be `blobContainer`, which is the only container type Flex Consumption currently supports."
+  }
 }
 
 variable "storage_shares_to_mount" {
@@ -2058,13 +2111,19 @@ DESCRIPTION
 variable "storage_user_assigned_identity_id" {
   type        = string
   default     = null
-  description = "The ID of the User Assigned Managed Identity for storage."
+  description = "The ID of the User Assigned Managed Identity for storage. Required when `function_app_uses_fc1` is `true` and `storage_authentication_type` is `UserAssignedIdentity`."
+
+  validation {
+    condition     = var.function_app_uses_fc1 != true || lower(coalesce(var.storage_authentication_type, "systemassignedidentity")) != "userassignedidentity" || var.storage_user_assigned_identity_id != null
+    error_message = "`storage_user_assigned_identity_id` is required when `function_app_uses_fc1` is `true` and `storage_authentication_type` is `UserAssignedIdentity`. Set it to the resource ID of the identity that can read the deployment container."
+  }
 }
 
 variable "storage_uses_managed_identity" {
   type        = bool
   default     = false
-  description = "Should the Storage Account use a Managed Identity? Defaults to `false`."
+  description = "Should the Function App's `AzureWebJobsStorage` app setting use a Managed Identity instead of a connection string? Defaults to `false`. This applies to non-Flex Consumption Function Apps; Flex Consumption apps use `storage_authentication_type` instead. Requires `storage_account_name` when `true`."
+  nullable    = false
 }
 
 variable "tags" {


### PR DESCRIPTION
Fixes #236

## The problem

Several variables default to `null`, so both Terraform and the generated README present them as optional. But the module dereferences them unconditionally once you pick a particular mode, and the resulting error names a local the caller has never seen.

The reporter hit this with Flex Consumption. `locals.body.tf` calls `lower(var.storage_container_type)` whenever `function_app_uses_fc1` is `true`, and `lower(null)` fails with a type error. Logic Apps have the same shape: `locals.app_settings.tf` interpolates `storage_account_name` and `storage_account_access_key` straight into a connection string, so a missing value produces "Invalid template interpolation value".

## The full set I found

I audited every `null`-defaulted variable that gets dereferenced unconditionally under some mode. These are the ones that actually break:

| Variable | Required when | Failure today | Fix |
| --- | --- | --- | --- |
| `fc1_runtime_name` | `function_app_uses_fc1 = true` | ARM rejects a null `runtime.name` | validation |
| `fc1_runtime_version` | `function_app_uses_fc1 = true` | ARM rejects a null `runtime.version` | validation |
| `storage_authentication_type` | `function_app_uses_fc1 = true` | `lower(null)` type error | validation |
| `storage_container_endpoint` | `function_app_uses_fc1 = true` | ARM rejects a missing `deployment.storage.value` | validation |
| `storage_user_assigned_identity_id` | `function_app_uses_fc1 = true` **and** `storage_authentication_type = "UserAssignedIdentity"` | ARM rejects the identity-less deployment config | validation |
| `storage_container_type` | `function_app_uses_fc1 = true` | `lower(null)` type error | **default** |
| `storage_account_name` | `kind = "logicapp"`, or `storage_uses_managed_identity = true` | template interpolation error / empty app setting | validation |
| `storage_account_access_key` | `kind = "logicapp"` | template interpolation error | validation |

I also added value validation for `fc1_runtime_name`, `storage_authentication_type` and `storage_container_type`, since a typo in any of those produces an equally unhelpful ARM error, and `nullable = false` on `storage_container_type`, `function_app_uses_fc1` and `storage_uses_managed_identity` (see the release-notes section below).

## Why validation blocks and not preconditions

The issue suggested `precondition` blocks on `azapi_resource.this`. That wouldn't help: `local.body` is its own node in the graph and gets evaluated before the resource node's checks run, so the `lower(null)` error still wins the race. Variable validation is evaluated first, so that's where the diagnosis belongs. Cross-object references in `validation` blocks landed in Terraform 1.9, and `terraform.tf` already pins `>= 1.9`, so we're clear.

The upshot is that this stays out of `locals.body.tf` and `locals.app_settings.tf` entirely — only `variables.tf`, the generated `README.md`, and a new unit test file.

## The default call

`storage_container_type` gets `default = "blobContainer"` rather than a required-ness check. `blobContainer` is the only value Flex Consumption supports today, and the variable is read only inside the `var.function_app_uses_fc1 ? ... : null` branch, so a non-null default can't change behaviour for web apps, Logic Apps, or non-FC1 Function Apps. I kept a validation on it too, so `fileShare` and friends get told no rather than being silently forwarded to ARM.

I deliberately did **not** require `storage_account_name` for plain (non-FC1) Function Apps. The code already null-guards that path, and someone may legitimately be supplying `AzureWebJobsStorage` through `app_settings`. Requiring it would break working configurations.

## On the two authentication variables

The reporter noticed that "authentication appears to have two different variables related to it," and they're right that it reads confusingly. `storage_authentication_type` only applies to Flex Consumption, where it feeds `functionAppConfig.deployment.storage.authentication.type`. `storage_uses_managed_identity` only applies to non-Flex Consumption Function Apps, where it switches the `AzureWebJobsStorage` app setting between a connection string and `AzureWebJobsStorage__accountName`. They never interact.

I've clarified both descriptions to say which mode each one governs, but I've left the names alone — renaming them is a breaking change and belongs in its own PR.

## Behaviour change worth calling out in release notes

Alongside the validations, three variables gained `nullable = false`: `storage_container_type`, `function_app_uses_fc1` and `storage_uses_managed_identity`. Anyone explicitly passing `null` to one of these now gets a hard plan-time error instead of the old behaviour.

The blast radius is tiny, but it isn't zero. `null` was the previous *default* for `storage_container_type`, and passing it explicitly was harmless on a non-FC1 app. Both booleans already blew up on an explicit `null` in `locals.body.tf` and `locals.app_settings.tf`, so no working configuration passes them, but `storage_container_type = null` on a web app really did work before and won't now. That's the right trade — the alternative is keeping a value that can only ever fail later — but it should be a documented line rather than a surprise.

## Testing

Added `tests/unit/conditionally_required_variables.tftest.hcl` with mocked providers: nine `expect_failures` runs covering each new conditional requirement, plus two `apply` runs asserting that `storage_container_type` defaults through to the body for FC1 and that `functionAppConfig` stays `null` otherwise.

```
Success! 11 passed, 0 failed.
```

`terraform fmt -recursive` and `terraform validate` are clean, and `README.md` was regenerated with the root `.terraform-docs.yml`. No live deployment was run locally.

### Why nine of the eleven runs use `command = plan`

Flagging this for reviewers, because AVM's testing guidance states "Unit tests use `command = apply` (NOT `command = plan`)" and this file appears to violate it. The two runs that assert on `local.body` do use `apply`. The nine `expect_failures` runs cannot.

Variable validation is evaluated during the plan stage, so a validation failure aborts the apply before it starts. Terraform then reports:

> Warning: Expected failure while planning
>
> A custom condition within `var.fc1_runtime_name` failed during the planning stage and prevented the requested apply operation. While this was an expected failure, the apply operation could not be executed and so the overall test case will be marked as a failure...

and fails the run despite the failure being the entire point of the test. Switching all eleven runs to `apply` takes the suite from 11 passed to 0 passed, 1 failed, 10 skipped — the first failure also cascades, skipping the rest.

This isn't specific to these variables. I reproduced it in a scratch module using the skill's own documented example verbatim (`references/terraform-test.md:245-254`): a `length(var.location) > 0` validation with `expect_failures = [var.location]` and `command = apply`. It fails the same way on Terraform 1.15.8, so that example does not pass as written and is worth correcting separately.

The same reasoning is recorded in a header comment in the test file, so it doesn't have to be rediscovered.

_Drafted by Claude Opus 5._


