### PR TITLE
fix: use the documented casing in the always_ready example

### DIFF
--- a/examples/always_ready/README.md
+++ b/examples/always_ready/README.md
@@ -156,9 +156,9 @@ module "avm_res_web_site" {
   os_type                           = "Linux"
   public_network_access_enabled     = true
   storage_account_access_key        = data.azapi_resource_action.storage_keys.output.keys[0].value
-  storage_authentication_type       = "userassignedidentity"
+  storage_authentication_type       = "UserAssignedIdentity"
   storage_container_endpoint        = azapi_resource.storage_container.id
-  storage_container_type            = "blobcontainer"
+  storage_container_type            = "blobContainer"
   storage_user_assigned_identity_id = azapi_resource.user_assigned_identity.id
   tags = {
     module          = "Azure/avm-res-web-site/azurerm"

--- a/examples/always_ready/main.tf
+++ b/examples/always_ready/main.tf
@@ -145,9 +145,9 @@ module "avm_res_web_site" {
   os_type                           = "Linux"
   public_network_access_enabled     = true
   storage_account_access_key        = data.azapi_resource_action.storage_keys.output.keys[0].value
-  storage_authentication_type       = "userassignedidentity"
+  storage_authentication_type       = "UserAssignedIdentity"
   storage_container_endpoint        = azapi_resource.storage_container.id
-  storage_container_type            = "blobcontainer"
+  storage_container_type            = "blobContainer"
   storage_user_assigned_identity_id = azapi_resource.user_assigned_identity.id
   tags = {
     module          = "Azure/avm-res-web-site/azurerm"


### PR DESCRIPTION
Fixes #354

## What changed

`examples/always_ready` used all-lowercase values for `storage_authentication_type` and `storage_container_type`, while `examples/flex_consumption` and the variable documentation use the ARM spellings `UserAssignedIdentity` and `blobContainer`.

Both forms deploy because the module normalizes them with `lower()` before sending them to ARM. The inconsistency was still worth fixing because examples are copied as documentation, and two examples should not teach different spellings for the same values.

## Why these spellings

The documented values match the constants in the ARM SDK and the validation used by `azurerm_function_app_flex_consumption`. `examples/flex_consumption` was already correct; `examples/always_ready` was the outlier.

This deliberately does not make validation case-sensitive. Existing case-insensitive inputs remain supported.

## Scope and validation

The change touches only `examples/always_ready/main.tf` and its generated README. The current head passes all 30 completed CI checks; the remaining check is intentionally skipped.

_Drafted by GPT-5.6 Sol._