### PR TITLE
fix: declare and wire the TFFR6/7/8 AzAPI variables in every module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1466,7 +1466,7 @@ Default: `null`
 
 Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type for resources this module declares, and by submodule name for resources its submodules declare. Paths use dot notation, and a change takes effect only after an apply. Configuration at an ignored path is not sent to Azure until the path is removed.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, so the fields belonging to submodules that manage their resource through `azapi_update_resource` or `azapi_resource_action` are declared for interface consistency and are not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, so the fields belonging to submodules that manage their resource through `azapi_update_resource` or `azapi_resource_action` exist for interface consistency. Setting a non-empty value on one of those fails the plan with an explicit error rather than being silently ignored.
 
 - `authorization_locks` - Paths ignored on the management locks.
 - `authorization_role_assignments` - Paths ignored on the role assignments.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 
@@ -1462,6 +1462,127 @@ Type: `bool`
 
 Default: `null`
 
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type for resources this module declares, and by submodule name for resources its submodules declare. Paths use dot notation, and a change takes effect only after an apply. Configuration at an ignored path is not sent to Azure until the path is removed.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, so the fields belonging to submodules that manage their resource through `azapi_update_resource` or `azapi_resource_action` are declared for interface consistency and are not applied yet.
+
+- `authorization_locks` - Paths ignored on the management locks.
+- `authorization_role_assignments` - Paths ignored on the role assignments.
+- `insights_diagnostic_settings` - Paths ignored on the diagnostic settings.
+- `network_private_endpoints` - Paths ignored on the private endpoints.
+- `network_private_endpoints_private_dns_zone_groups` - Paths ignored on the private DNS zone groups.
+- `web_sites` - Paths ignored on the App Service site.
+- `certificate` - Paths passed to the certificate submodule.
+- `config_appsettings` - Paths passed to the app settings submodule.
+- `config_authsettings` - Paths passed to the v1 auth settings submodule.
+- `config_authsettingsv2` - Paths passed to the v2 auth settings submodule.
+- `config_azurestorageaccounts` - Paths passed to the storage account mounts submodule.
+- `config_backup` - Paths passed to the backup submodule.
+- `config_connectionstrings` - Paths passed to the connection strings submodule.
+- `config_logs` - Paths passed to the logs submodule.
+- `config_metadata` - Paths passed to the site metadata submodule.
+- `config_slotconfignames` - Paths passed to the sticky settings submodule.
+- `extensions_zipdeploy` - Paths passed to the zip deployment submodule.
+- `hostname_binding` - Paths passed to the hostname binding submodules.
+- `publishing_credential_policy` - Paths passed to the publishing credential policy submodules.
+- `slot` - Paths passed to the deployment slot submodule.
+
+Type:
+
+```hcl
+object({
+    authorization_locks                               = optional(list(string), [])
+    authorization_role_assignments                    = optional(list(string), [])
+    insights_diagnostic_settings                      = optional(list(string), [])
+    network_private_endpoints                         = optional(list(string), [])
+    network_private_endpoints_private_dns_zone_groups = optional(list(string), [])
+    web_sites                                         = optional(list(string), [])
+
+    certificate = optional(object({
+      web_certificates = optional(list(string), [])
+    }), {})
+    config_appsettings = optional(object({
+      web_sites_config       = optional(list(string), [])
+      web_sites_slots_config = optional(list(string), [])
+    }), {})
+    config_authsettings = optional(object({
+      web_sites_config = optional(list(string), [])
+    }), {})
+    config_authsettingsv2 = optional(object({
+      web_sites_config = optional(list(string), [])
+    }), {})
+    config_azurestorageaccounts = optional(object({
+      web_sites       = optional(list(string), [])
+      web_sites_slots = optional(list(string), [])
+    }), {})
+    config_backup = optional(object({
+      web_sites_config = optional(list(string), [])
+    }), {})
+    config_connectionstrings = optional(object({
+      web_sites_config       = optional(list(string), [])
+      web_sites_slots_config = optional(list(string), [])
+    }), {})
+    config_logs = optional(object({
+      web_sites_config = optional(list(string), [])
+    }), {})
+    config_metadata = optional(object({
+      web_sites_config       = optional(list(string), [])
+      web_sites_slots_config = optional(list(string), [])
+    }), {})
+    config_slotconfignames = optional(object({
+      web_sites_config = optional(list(string), [])
+    }), {})
+    extensions_zipdeploy = optional(object({
+      web_sites       = optional(list(string), [])
+      web_sites_slots = optional(list(string), [])
+    }), {})
+    hostname_binding = optional(object({
+      web_sites_host_name_bindings       = optional(list(string), [])
+      web_sites_slots_host_name_bindings = optional(list(string), [])
+    }), {})
+    publishing_credential_policy = optional(object({
+      web_sites_basic_publishing_credentials_policies       = optional(list(string), [])
+      web_sites_slots_basic_publishing_credentials_policies = optional(list(string), [])
+    }), {})
+    slot = optional(object({
+      authorization_locks                               = optional(list(string), [])
+      authorization_role_assignments                    = optional(list(string), [])
+      network_private_endpoints                         = optional(list(string), [])
+      network_private_endpoints_private_dns_zone_groups = optional(list(string), [])
+      web_sites_slots                                   = optional(list(string), [])
+
+      config_appsettings = optional(object({
+        web_sites_config       = optional(list(string), [])
+        web_sites_slots_config = optional(list(string), [])
+      }), {})
+      config_azurestorageaccounts = optional(object({
+        web_sites       = optional(list(string), [])
+        web_sites_slots = optional(list(string), [])
+      }), {})
+      config_connectionstrings = optional(object({
+        web_sites_config       = optional(list(string), [])
+        web_sites_slots_config = optional(list(string), [])
+      }), {})
+      config_metadata = optional(object({
+        web_sites_config       = optional(list(string), [])
+        web_sites_slots_config = optional(list(string), [])
+      }), {})
+      extensions_zipdeploy = optional(object({
+        web_sites       = optional(list(string), [])
+        web_sites_slots = optional(list(string), [])
+      }), {})
+      publishing_credential_policy = optional(object({
+        web_sites_basic_publishing_credentials_policies       = optional(list(string), [])
+        web_sites_slots_basic_publishing_credentials_policies = optional(list(string), [])
+      }), {})
+    }), {})
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_instance_memory_in_mb"></a> [instance\_memory\_in\_mb](#input\_instance\_memory\_in\_mb)
 
 Description: The amount of memory to allocate for Flex Consumption instances. Defaults to `2048`.
@@ -1733,33 +1854,144 @@ object({
 
 Default: `null`
 
-### <a name="input_retry"></a> [retry](#input\_retry)
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
 
-Description: Retry configuration for all azapi resources. Defaults to retrying on 409 Conflict errors caused by concurrent operations.
+Description: AzAPI resource types and API versions, keyed by resource type for resources this module declares, and by submodule name for resources its submodules declare. Each submodule owns the API-version defaults for its own resources, so nested fields have no defaults here.
 
-- `error_message_regex` - (Required) A list of regular expressions to match against error messages. If any match, the operation will be retried.
-- `interval_seconds` - (Optional) The initial interval in seconds between retries. Defaults to `10`.
-- `max_retries` - (Optional) The maximum number of retries. Defaults to `3`.
+- `authorization_locks` - Resource type and API version for the management locks.
+- `authorization_role_assignments` - Resource type and API version for the role assignments.
+- `insights_diagnostic_settings` - Resource type and API version for the diagnostic settings.
+- `network_private_endpoints` - Resource type and API version for the private endpoints.
+- `network_private_endpoints_private_dns_zone_groups` - Resource type and API version for the private DNS zone groups.
+- `web_sites` - Resource type and API version for the App Service site.
+- `certificate` - Resource-type overrides passed to the certificate submodule.
+- `config_appsettings` - Resource-type overrides passed to the app settings submodule.
+- `config_authsettings` - Resource-type overrides passed to the v1 auth settings submodule.
+- `config_authsettingsv2` - Resource-type overrides passed to the v2 auth settings submodule.
+- `config_azurestorageaccounts` - Resource-type overrides passed to the storage account mounts submodule.
+- `config_backup` - Resource-type overrides passed to the backup submodule.
+- `config_connectionstrings` - Resource-type overrides passed to the connection strings submodule.
+- `config_logs` - Resource-type overrides passed to the logs submodule.
+- `config_metadata` - Resource-type overrides passed to the site metadata submodule.
+- `config_slotconfignames` - Resource-type overrides passed to the sticky settings submodule.
+- `extensions_zipdeploy` - Resource-type overrides passed to the zip deployment submodule.
+- `hostname_binding` - Resource-type overrides passed to the hostname binding submodules.
+- `publishing_credential_policy` - Resource-type overrides passed to the publishing credential policy submodules.
+- `slot` - Resource-type overrides passed to the deployment slot submodule.
 
 Type:
 
 ```hcl
 object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    authorization_locks                               = optional(string, "Microsoft.Authorization/locks@2020-05-01")
+    authorization_role_assignments                    = optional(string, "Microsoft.Authorization/roleAssignments@2022-04-01")
+    insights_diagnostic_settings                      = optional(string, "Microsoft.Insights/diagnosticSettings@2021-05-01-preview")
+    network_private_endpoints                         = optional(string, "Microsoft.Network/privateEndpoints@2024-05-01")
+    network_private_endpoints_private_dns_zone_groups = optional(string, "Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-05-01")
+    web_sites                                         = optional(string, "Microsoft.Web/sites@2025-03-01")
+
+    certificate = optional(object({
+      web_certificates = optional(string)
+    }), {})
+    config_appsettings = optional(object({
+      web_sites_config       = optional(string)
+      web_sites_slots_config = optional(string)
+    }), {})
+    config_authsettings = optional(object({
+      web_sites_config = optional(string)
+    }), {})
+    config_authsettingsv2 = optional(object({
+      web_sites_config = optional(string)
+    }), {})
+    config_azurestorageaccounts = optional(object({
+      web_sites       = optional(string)
+      web_sites_slots = optional(string)
+    }), {})
+    config_backup = optional(object({
+      web_sites_config = optional(string)
+    }), {})
+    config_connectionstrings = optional(object({
+      web_sites_config       = optional(string)
+      web_sites_slots_config = optional(string)
+    }), {})
+    config_logs = optional(object({
+      web_sites_config = optional(string)
+    }), {})
+    config_metadata = optional(object({
+      web_sites_config       = optional(string)
+      web_sites_slots_config = optional(string)
+    }), {})
+    config_slotconfignames = optional(object({
+      web_sites_config = optional(string)
+    }), {})
+    extensions_zipdeploy = optional(object({
+      web_sites       = optional(string)
+      web_sites_slots = optional(string)
+    }), {})
+    hostname_binding = optional(object({
+      web_sites_host_name_bindings       = optional(string)
+      web_sites_slots_host_name_bindings = optional(string)
+    }), {})
+    publishing_credential_policy = optional(object({
+      web_sites_basic_publishing_credentials_policies       = optional(string)
+      web_sites_slots_basic_publishing_credentials_policies = optional(string)
+    }), {})
+    slot = optional(object({
+      authorization_locks                               = optional(string)
+      authorization_role_assignments                    = optional(string)
+      network_private_endpoints                         = optional(string)
+      network_private_endpoints_private_dns_zone_groups = optional(string)
+      web_sites_slots                                   = optional(string)
+
+      config_appsettings = optional(object({
+        web_sites_config       = optional(string)
+        web_sites_slots_config = optional(string)
+      }), {})
+      config_azurestorageaccounts = optional(object({
+        web_sites       = optional(string)
+        web_sites_slots = optional(string)
+      }), {})
+      config_connectionstrings = optional(object({
+        web_sites_config       = optional(string)
+        web_sites_slots_config = optional(string)
+      }), {})
+      config_metadata = optional(object({
+        web_sites_config       = optional(string)
+        web_sites_slots_config = optional(string)
+      }), {})
+      extensions_zipdeploy = optional(object({
+        web_sites       = optional(string)
+        web_sites_slots = optional(string)
+      }), {})
+      publishing_credential_policy = optional(object({
+        web_sites_basic_publishing_credentials_policies       = optional(string)
+        web_sites_slots_basic_publishing_credentials_policies = optional(string)
+      }), {})
+    }), {})
   })
 ```
 
-Default:
+Default: `{}`
 
-```json
-{
-  "error_message_regex": [
-    "Cannot modify this site because another operation is in progress"
-  ]
-}
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for the AzAPI resources declared by this module and its submodules. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
 ```
+
+Default: `{}`
 
 ### <a name="input_role_assignments"></a> [role\_assignments](#input\_role\_assignments)
 

--- a/examples/always_ready/README.md
+++ b/examples/always_ready/README.md
@@ -175,7 +175,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/always_ready/terraform.tf
+++ b/examples/always_ready/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/application_stack/README.md
+++ b/examples/application_stack/README.md
@@ -202,7 +202,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/application_stack/terraform.tf
+++ b/examples/application_stack/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/auto_heal_enabled/README.md
+++ b/examples/auto_heal_enabled/README.md
@@ -137,7 +137,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/auto_heal_enabled/terraform.tf
+++ b/examples/auto_heal_enabled/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/basic_auth/README.md
+++ b/examples/basic_auth/README.md
@@ -157,7 +157,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/basic_auth/terraform.tf
+++ b/examples/basic_auth/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/custom_container/README.md
+++ b/examples/custom_container/README.md
@@ -136,7 +136,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/custom_container/terraform.tf
+++ b/examples/custom_container/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/custom_domain/README.md
+++ b/examples/custom_domain/README.md
@@ -348,7 +348,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/custom_domain/terraform.tf
+++ b/examples/custom_domain/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -97,7 +97,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/default/terraform.tf
+++ b/examples/default/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/deployment_slot_with_interfaces/README.md
+++ b/examples/deployment_slot_with_interfaces/README.md
@@ -327,7 +327,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/deployment_slot_with_interfaces/terraform.tf
+++ b/examples/deployment_slot_with_interfaces/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/deployment_slots_with_sensitive_values/README.md
+++ b/examples/deployment_slots_with_sensitive_values/README.md
@@ -178,7 +178,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/deployment_slots_with_sensitive_values/terraform.tf
+++ b/examples/deployment_slots_with_sensitive_values/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/existing/README.md
+++ b/examples/existing/README.md
@@ -185,7 +185,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/existing/terraform.tf
+++ b/examples/existing/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/flex_consumption/README.md
+++ b/examples/flex_consumption/README.md
@@ -156,7 +156,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/flex_consumption/terraform.tf
+++ b/examples/flex_consumption/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/function_app/README.md
+++ b/examples/function_app/README.md
@@ -127,7 +127,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/function_app/terraform.tf
+++ b/examples/function_app/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/interfaces/README.md
+++ b/examples/interfaces/README.md
@@ -346,7 +346,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/interfaces/terraform.tf
+++ b/examples/interfaces/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/ip_restriction/README.md
+++ b/examples/ip_restriction/README.md
@@ -147,7 +147,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/ip_restriction/terraform.tf
+++ b/examples/ip_restriction/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/logic_app/README.md
+++ b/examples/logic_app/README.md
@@ -203,7 +203,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/logic_app/terraform.tf
+++ b/examples/logic_app/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/logs/README.md
+++ b/examples/logs/README.md
@@ -271,7 +271,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/logs/terraform.tf
+++ b/examples/logs/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/mounted_storage/README.md
+++ b/examples/mounted_storage/README.md
@@ -213,7 +213,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/mounted_storage/terraform.tf
+++ b/examples/mounted_storage/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/storage_uses_managed_identity/README.md
+++ b/examples/storage_uses_managed_identity/README.md
@@ -148,7 +148,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/storage_uses_managed_identity/terraform.tf
+++ b/examples/storage_uses_managed_identity/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/submodules/README.md
+++ b/examples/submodules/README.md
@@ -196,7 +196,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/submodules/terraform.tf
+++ b/examples/submodules/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/web_app/README.md
+++ b/examples/web_app/README.md
@@ -126,7 +126,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/web_app/terraform.tf
+++ b/examples/web_app/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/windows_dotnet10/README.md
+++ b/examples/windows_dotnet10/README.md
@@ -114,7 +114,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0, < 4.0.0)
 

--- a/examples/windows_dotnet10/terraform.tf
+++ b/examples/windows_dotnet10/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/zip_deploy_file/README.md
+++ b/examples/zip_deploy_file/README.md
@@ -179,7 +179,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_archive"></a> [archive](#requirement\_archive) (>= 2.0.0, < 3.0.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.0.0, < 5.0.0)
 

--- a/examples/zip_deploy_file/terraform.tf
+++ b/examples/zip_deploy_file/terraform.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/main.auth.tf
+++ b/main.auth.tf
@@ -13,13 +13,13 @@ module "config_authsettings" {
   facebook                       = each.value.facebook
   github                         = each.value.github
   google                         = each.value.google
+  ignore_body_changes            = var.ignore_body_changes.config_authsettings
   issuer                         = each.value.issuer
   microsoft                      = each.value.microsoft
-  ignore_body_changes            = var.ignore_body_changes.config_authsettings
   resource_types                 = var.resource_types.config_authsettings
   retry                          = var.retry
-  timeouts                       = var.timeouts
   runtime_version                = each.value.runtime_version
+  timeouts                       = var.timeouts
   token_refresh_extension_hours  = each.value.token_refresh_extension_hours
   token_store_enabled            = each.value.token_store_enabled
   twitter                        = each.value.twitter
@@ -39,14 +39,14 @@ module "config_authsettingsv2" {
   forward_proxy_custom_proto_header_name = each.value.forward_proxy_custom_proto_header_name
   http_route_api_prefix                  = each.value.http_route_api_prefix
   identity_providers                     = each.value.identity_providers
+  ignore_body_changes                    = var.ignore_body_changes.config_authsettingsv2
   login                                  = each.value.login
   redirect_to_provider                   = each.value.redirect_to_provider
   require_authentication                 = each.value.require_authentication
   require_https                          = each.value.require_https
-  ignore_body_changes                    = var.ignore_body_changes.config_authsettingsv2
   resource_types                         = var.resource_types.config_authsettingsv2
   retry                                  = var.retry
-  timeouts                               = var.timeouts
   runtime_version                        = each.value.runtime_version
+  timeouts                               = var.timeouts
   unauthenticated_client_action          = each.value.unauthenticated_client_action
 }

--- a/main.auth.tf
+++ b/main.auth.tf
@@ -15,7 +15,10 @@ module "config_authsettings" {
   google                         = each.value.google
   issuer                         = each.value.issuer
   microsoft                      = each.value.microsoft
+  ignore_body_changes            = var.ignore_body_changes.config_authsettings
+  resource_types                 = var.resource_types.config_authsettings
   retry                          = var.retry
+  timeouts                       = var.timeouts
   runtime_version                = each.value.runtime_version
   token_refresh_extension_hours  = each.value.token_refresh_extension_hours
   token_store_enabled            = each.value.token_store_enabled
@@ -40,7 +43,10 @@ module "config_authsettingsv2" {
   redirect_to_provider                   = each.value.redirect_to_provider
   require_authentication                 = each.value.require_authentication
   require_https                          = each.value.require_https
+  ignore_body_changes                    = var.ignore_body_changes.config_authsettingsv2
+  resource_types                         = var.resource_types.config_authsettingsv2
   retry                                  = var.retry
+  timeouts                               = var.timeouts
   runtime_version                        = each.value.runtime_version
   unauthenticated_client_action          = each.value.unauthenticated_client_action
 }

--- a/main.backup.tf
+++ b/main.backup.tf
@@ -2,10 +2,13 @@ module "config_backup" {
   source   = "./modules/config_backup"
   for_each = var.backup
 
-  parent_id   = azapi_resource.this.id
-  backup_name = coalesce(each.value.name, "backup-${var.name}")
-  enabled     = each.value.enabled
-  retry       = var.retry
+  parent_id           = azapi_resource.this.id
+  backup_name         = coalesce(each.value.name, "backup-${var.name}")
+  enabled             = each.value.enabled
+  ignore_body_changes = var.ignore_body_changes.config_backup
+  resource_types      = var.resource_types.config_backup
+  retry               = var.retry
+  timeouts            = var.timeouts
   schedule = each.value.schedule != null ? {
     for sk, sv in each.value.schedule : sk => sv
   }[keys(each.value.schedule)[0]] : null

--- a/main.backup.tf
+++ b/main.backup.tf
@@ -8,9 +8,9 @@ module "config_backup" {
   ignore_body_changes = var.ignore_body_changes.config_backup
   resource_types      = var.resource_types.config_backup
   retry               = var.retry
-  timeouts            = var.timeouts
   schedule = each.value.schedule != null ? {
     for sk, sv in each.value.schedule : sk => sv
   }[keys(each.value.schedule)[0]] : null
   storage_account_url = each.value.storage_account_url
+  timeouts            = var.timeouts
 }

--- a/main.config.tf
+++ b/main.config.tf
@@ -1,17 +1,23 @@
 module "config_appsettings" {
   source = "./modules/config_appsettings"
 
-  app_settings = local.merged_app_settings
-  parent_id    = azapi_resource.this.id
-  retry        = var.retry
+  app_settings        = local.merged_app_settings
+  parent_id           = azapi_resource.this.id
+  ignore_body_changes = var.ignore_body_changes.config_appsettings
+  resource_types      = var.resource_types.config_appsettings
+  retry               = var.retry
+  timeouts            = var.timeouts
 }
 
 module "config_connectionstrings" {
   source = "./modules/config_connectionstrings"
 
-  connection_strings = var.connection_strings
-  parent_id          = azapi_resource.this.id
-  retry              = var.retry
+  connection_strings  = var.connection_strings
+  parent_id           = azapi_resource.this.id
+  ignore_body_changes = var.ignore_body_changes.config_connectionstrings
+  resource_types      = var.resource_types.config_connectionstrings
+  retry               = var.retry
+  timeouts            = var.timeouts
 }
 
 module "config_azurestorageaccounts" {
@@ -19,15 +25,21 @@ module "config_azurestorageaccounts" {
 
   parent_id               = azapi_resource.this.id
   storage_shares_to_mount = var.storage_shares_to_mount
+  ignore_body_changes     = var.ignore_body_changes.config_azurestorageaccounts
+  resource_types          = var.resource_types.config_azurestorageaccounts
   retry                   = var.retry
+  timeouts                = var.timeouts
 }
 
 module "config_metadata" {
   source = "./modules/config_metadata"
 
-  metadata  = { for m in coalesce(module.site_config_helpers.site_config_metadata, []) : m.name => m.value }
-  parent_id = azapi_resource.this.id
-  retry     = var.retry
+  metadata            = { for m in coalesce(module.site_config_helpers.site_config_metadata, []) : m.name => m.value }
+  parent_id           = azapi_resource.this.id
+  ignore_body_changes = var.ignore_body_changes.config_metadata
+  resource_types      = var.resource_types.config_metadata
+  retry               = var.retry
+  timeouts            = var.timeouts
 }
 
 module "config_slotconfignames" {
@@ -37,25 +49,34 @@ module "config_slotconfignames" {
   parent_id               = azapi_resource.this.id
   app_setting_names       = flatten([for k, v in var.sticky_settings : coalesce(v.app_setting_names, [])])
   connection_string_names = flatten([for k, v in var.sticky_settings : coalesce(v.connection_string_names, [])])
+  ignore_body_changes     = var.ignore_body_changes.config_slotconfignames
+  resource_types          = var.resource_types.config_slotconfignames
   retry                   = var.retry
+  timeouts                = var.timeouts
 }
 
 module "ftp_publishing_credential_policy" {
   source   = "./modules/publishing_credential_policy"
   for_each = !var.ftp_publish_basic_authentication_enabled ? { "default" = {} } : {}
 
-  name      = "ftp"
-  parent_id = azapi_resource.this.id
-  allow     = false
-  retry     = var.retry
+  name                = "ftp"
+  parent_id           = azapi_resource.this.id
+  allow               = false
+  ignore_body_changes = var.ignore_body_changes.publishing_credential_policy
+  resource_types      = var.resource_types.publishing_credential_policy
+  retry               = var.retry
+  timeouts            = var.timeouts
 }
 
 module "scm_publishing_credential_policy" {
   source   = "./modules/publishing_credential_policy"
   for_each = !var.scm_publish_basic_authentication_enabled ? { "default" = {} } : {}
 
-  name      = "scm"
-  parent_id = azapi_resource.this.id
-  allow     = false
-  retry     = var.retry
+  name                = "scm"
+  parent_id           = azapi_resource.this.id
+  allow               = false
+  ignore_body_changes = var.ignore_body_changes.publishing_credential_policy
+  resource_types      = var.resource_types.publishing_credential_policy
+  retry               = var.retry
+  timeouts            = var.timeouts
 }

--- a/main.custom_domains.tf
+++ b/main.custom_domains.tf
@@ -11,7 +11,10 @@ module "certificate" {
   key_vault_secret_name = each.value.key_vault_secret_name
   password              = each.value.password
   pfx_blob              = each.value.pfx_blob
+  ignore_body_changes   = var.ignore_body_changes.certificate
+  resource_types        = var.resource_types.certificate
   retry                 = var.retry
+  timeouts              = var.timeouts
   tags                  = each.value.tags
 }
 
@@ -19,11 +22,14 @@ module "hostname_binding" {
   source   = "./modules/hostname_binding"
   for_each = var.custom_domains
 
-  hostname   = each.value.hostname
-  parent_id  = azapi_resource.this.id
-  retry      = var.retry
-  ssl_state  = each.value.ssl_state
-  thumbprint = each.value.certificate_key != null ? module.certificate[each.value.certificate_key].thumbprint : each.value.thumbprint
+  hostname            = each.value.hostname
+  parent_id           = azapi_resource.this.id
+  ignore_body_changes = var.ignore_body_changes.hostname_binding
+  resource_types      = var.resource_types.hostname_binding
+  retry               = var.retry
+  timeouts            = var.timeouts
+  ssl_state           = each.value.ssl_state
+  thumbprint          = each.value.certificate_key != null ? module.certificate[each.value.certificate_key].thumbprint : each.value.thumbprint
 }
 
 locals {
@@ -45,9 +51,12 @@ module "slot_hostname_binding" {
   source   = "./modules/hostname_binding"
   for_each = local.slot_custom_domains
 
-  hostname   = each.value.hostname
-  parent_id  = module.slot[each.value.slot_key].resource_id
-  retry      = var.retry
-  ssl_state  = each.value.ssl_state
-  thumbprint = each.value.certificate_key != null ? module.certificate[each.value.certificate_key].thumbprint : each.value.thumbprint
+  hostname            = each.value.hostname
+  parent_id           = module.slot[each.value.slot_key].resource_id
+  ignore_body_changes = var.ignore_body_changes.hostname_binding
+  resource_types      = var.resource_types.hostname_binding
+  retry               = var.retry
+  timeouts            = var.timeouts
+  ssl_state           = each.value.ssl_state
+  thumbprint          = each.value.certificate_key != null ? module.certificate[each.value.certificate_key].thumbprint : each.value.thumbprint
 }

--- a/main.custom_domains.tf
+++ b/main.custom_domains.tf
@@ -7,15 +7,15 @@ module "certificate" {
   parent_id             = var.parent_id
   server_farm_id        = var.service_plan_resource_id
   host_names            = each.value.host_names
+  ignore_body_changes   = var.ignore_body_changes.certificate
   key_vault_id          = each.value.key_vault_id
   key_vault_secret_name = each.value.key_vault_secret_name
   password              = each.value.password
   pfx_blob              = each.value.pfx_blob
-  ignore_body_changes   = var.ignore_body_changes.certificate
   resource_types        = var.resource_types.certificate
   retry                 = var.retry
-  timeouts              = var.timeouts
   tags                  = each.value.tags
+  timeouts              = var.timeouts
 }
 
 module "hostname_binding" {
@@ -27,9 +27,9 @@ module "hostname_binding" {
   ignore_body_changes = var.ignore_body_changes.hostname_binding
   resource_types      = var.resource_types.hostname_binding
   retry               = var.retry
-  timeouts            = var.timeouts
   ssl_state           = each.value.ssl_state
   thumbprint          = each.value.certificate_key != null ? module.certificate[each.value.certificate_key].thumbprint : each.value.thumbprint
+  timeouts            = var.timeouts
 }
 
 locals {
@@ -56,7 +56,7 @@ module "slot_hostname_binding" {
   ignore_body_changes = var.ignore_body_changes.hostname_binding
   resource_types      = var.resource_types.hostname_binding
   retry               = var.retry
-  timeouts            = var.timeouts
   ssl_state           = each.value.ssl_state
   thumbprint          = each.value.certificate_key != null ? module.certificate[each.value.certificate_key].thumbprint : each.value.thumbprint
+  timeouts            = var.timeouts
 }

--- a/main.deploy.tf
+++ b/main.deploy.tf
@@ -18,9 +18,12 @@ module "extensions_zipdeploy" {
   source   = "./modules/extensions_zipdeploy"
   for_each = var.zip_deploy_file != null ? { "default" = {} } : {}
 
-  parent_id       = azapi_resource.this.id
-  zip_deploy_file = var.zip_deploy_file
-  retry           = var.retry
+  parent_id           = azapi_resource.this.id
+  zip_deploy_file     = var.zip_deploy_file
+  ignore_body_changes = var.ignore_body_changes.extensions_zipdeploy
+  resource_types      = var.resource_types.extensions_zipdeploy
+  retry               = var.retry
+  timeouts            = var.timeouts
 
   depends_on = [
     time_sleep.wait_before_zip_deploy,

--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -22,14 +22,26 @@ resource "azapi_resource" "lock" {
 
   name                   = each.value.name
   parent_id              = azapi_resource.this.id
-  type                   = each.value.type
+  type                   = var.resource_types.authorization_locks
   body                   = each.value.body
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.authorization_locks) > 0 ? var.ignore_body_changes.authorization_locks : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 resource "azapi_resource" "role_assignment" {
@@ -37,15 +49,27 @@ resource "azapi_resource" "role_assignment" {
 
   name                   = each.value.name
   parent_id              = azapi_resource.this.id
-  type                   = each.value.type
+  type                   = var.resource_types.authorization_role_assignments
   body                   = each.value.body
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.authorization_role_assignments) > 0 ? var.ignore_body_changes.authorization_role_assignments : null
   ignore_null_property   = true
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 resource "azapi_resource" "private_endpoint" {
@@ -54,15 +78,27 @@ resource "azapi_resource" "private_endpoint" {
   location               = coalesce(try(var.private_endpoints[each.key].location, null), var.location)
   name                   = each.value.name
   parent_id              = var.parent_id
-  type                   = each.value.type
+  type                   = var.resource_types.network_private_endpoints
   body                   = each.value.body
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.network_private_endpoints) > 0 ? var.ignore_body_changes.network_private_endpoints : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
   retry                  = var.retry
   tags                   = each.value.tags
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 resource "azapi_resource" "private_dns_zone_group" {
@@ -70,14 +106,26 @@ resource "azapi_resource" "private_dns_zone_group" {
 
   name                   = each.value.name
   parent_id              = azapi_resource.private_endpoint[each.key].id
-  type                   = each.value.type
+  type                   = var.resource_types.network_private_endpoints_private_dns_zone_groups
   body                   = each.value.body
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.network_private_endpoints_private_dns_zone_groups) > 0 ? var.ignore_body_changes.network_private_endpoints_private_dns_zone_groups : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 resource "azapi_resource" "lock_private_endpoint" {
@@ -85,14 +133,26 @@ resource "azapi_resource" "lock_private_endpoint" {
 
   name                   = each.value.name
   parent_id              = azapi_resource.private_endpoint[each.value.private_endpoint_key].id
-  type                   = each.value.type
+  type                   = var.resource_types.authorization_locks
   body                   = each.value.body
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.authorization_locks) > 0 ? var.ignore_body_changes.authorization_locks : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 resource "azapi_resource" "role_assignment_private_endpoint" {
@@ -100,14 +160,26 @@ resource "azapi_resource" "role_assignment_private_endpoint" {
 
   name                   = each.value.name
   parent_id              = azapi_resource.private_endpoint[each.value.pe_key].id
-  type                   = each.value.type
+  type                   = var.resource_types.authorization_role_assignments
   body                   = each.value.body
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.authorization_role_assignments) > 0 ? var.ignore_body_changes.authorization_role_assignments : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 resource "azapi_resource" "diagnostic_setting" {
@@ -115,13 +187,25 @@ resource "azapi_resource" "diagnostic_setting" {
 
   name                   = each.value.name
   parent_id              = azapi_resource.this.id
-  type                   = each.value.type
+  type                   = var.resource_types.insights_diagnostic_settings
   body                   = each.value.body
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.insights_diagnostic_settings) > 0 ? var.ignore_body_changes.insights_diagnostic_settings : null
   ignore_null_property   = true
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }

--- a/main.logs.tf
+++ b/main.logs.tf
@@ -11,5 +11,8 @@ module "config_logs" {
   http_logs = length(each.value.http_logs) > 0 ? {
     for hlk, hlv in each.value.http_logs : hlk => hlv
   }[keys(each.value.http_logs)[0]] : null
-  retry = var.retry
+  ignore_body_changes = var.ignore_body_changes.config_logs
+  resource_types      = var.resource_types.config_logs
+  retry               = var.retry
+  timeouts            = var.timeouts
 }

--- a/main.slots.tf
+++ b/main.slots.tf
@@ -47,7 +47,10 @@ module "slot" {
   public_network_access_enabled           = each.value.public_network_access_enabled
   redundancy_mode                         = each.value.redundancy_mode
   resource_config                         = each.value.resource_config
+  ignore_body_changes                     = var.ignore_body_changes.slot
+  resource_types                          = var.resource_types.slot
   retry                                   = var.retry
+  timeouts                                = var.timeouts
   role_assignments                        = each.value.role_assignments
   scm_site_also_stopped                   = each.value.scm_site_also_stopped
   sensitive_app_settings                  = lookup(var.slot_sensitive_app_settings, each.key, {})
@@ -79,12 +82,23 @@ resource "azapi_resource_action" "active_slot" {
   action      = "slotsswap"
   method      = "POST"
   resource_id = azapi_resource.this.id
-  type        = "Microsoft.Web/sites@2025-03-01"
+  type        = var.resource_types.web_sites
   body = {
     targetSlot   = coalesce(var.deployment_slots[var.app_service_active_slot.slot_key].name, var.app_service_active_slot.slot_key)
     preserveVnet = !var.app_service_active_slot.overwrite_network_config
   }
   retry = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 
   depends_on = [module.slot]
 }

--- a/main.slots.tf
+++ b/main.slots.tf
@@ -32,6 +32,7 @@ module "slot" {
   hosting_environment_id                   = each.value.hosting_environment_id
   https_only                               = each.value.https_only
   hyper_v                                  = each.value.hyper_v
+  ignore_body_changes                      = var.ignore_body_changes.slot
   ip_mode                                  = each.value.ip_mode
   is_function_app                          = local.is_function_app
   key_vault_reference_identity             = each.value.key_vault_reference_identity
@@ -47,10 +48,8 @@ module "slot" {
   public_network_access_enabled           = each.value.public_network_access_enabled
   redundancy_mode                         = each.value.redundancy_mode
   resource_config                         = each.value.resource_config
-  ignore_body_changes                     = var.ignore_body_changes.slot
   resource_types                          = var.resource_types.slot
   retry                                   = var.retry
-  timeouts                                = var.timeouts
   role_assignments                        = each.value.role_assignments
   scm_site_also_stopped                   = each.value.scm_site_also_stopped
   sensitive_app_settings                  = lookup(var.slot_sensitive_app_settings, each.key, {})
@@ -64,6 +63,7 @@ module "slot" {
   }
   storage_shares_to_mount                        = each.value.storage_shares_to_mount
   tags                                           = var.all_child_resources_inherit_tags ? merge(var.tags, each.value.tags) : each.value.tags
+  timeouts                                       = var.timeouts
   virtual_network_subnet_id                      = each.value.virtual_network_subnet_id
   vnet_application_traffic_enabled               = each.value.vnet_application_traffic_enabled
   vnet_backup_restore_enabled                    = each.value.vnet_backup_restore_enabled

--- a/main.tf
+++ b/main.tf
@@ -2,10 +2,11 @@ resource "azapi_resource" "this" {
   location             = var.location
   name                 = var.name
   parent_id            = var.parent_id
-  type                 = "Microsoft.Web/sites@2025-03-01"
+  type                 = var.resource_types.web_sites
   body                 = local.body
   create_headers       = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers       = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes  = length(var.ignore_body_changes.web_sites) > 0 ? var.ignore_body_changes.web_sites : null
   ignore_null_property = true
   read_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = [

--- a/modules/certificate/README.md
+++ b/modules/certificate/README.md
@@ -35,7 +35,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 ## Resources
 
@@ -84,6 +84,22 @@ Type: `list(string)`
 
 Default: `null`
 
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+- `web_certificates` - Paths ignored on the certificate.
+
+Type:
+
+```hcl
+object({
+    web_certificates = optional(list(string), [])
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id)
 
 Description: (Optional) The resource ID of the Key Vault that contains the certificate.
@@ -121,27 +137,69 @@ Type: `string`
 
 Default: `null`
 
-### <a name="input_retry"></a> [retry](#input\_retry)
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
 
-Description: (Optional) Retry configuration for the underlying azapi resource.
+Description: AzAPI resource types and API versions used by this module.
+
+- `web_certificates` - Resource type and API version for the certificate.
 
 Type:
 
 ```hcl
 object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    web_certificates = optional(string, "Microsoft.Web/certificates@2025-03-01")
   })
 ```
 
-Default: `null`
+Default: `{}`
+
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
+```
+
+Default: `{}`
 
 ### <a name="input_tags"></a> [tags](#input\_tags)
 
 Description: (Optional) Tags applied to the certificate resource.
 
 Type: `map(string)`
+
+Default: `null`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
 
 Default: `null`
 

--- a/modules/certificate/main.tf
+++ b/modules/certificate/main.tf
@@ -2,7 +2,7 @@ resource "azapi_resource" "this" {
   location  = var.location
   name      = var.name
   parent_id = var.parent_id
-  type      = "Microsoft.Web/certificates@2025-03-01"
+  type      = var.resource_types.web_certificates
   body = {
     properties = {
       serverFarmId       = var.server_farm_id
@@ -13,6 +13,7 @@ resource "azapi_resource" "this" {
       hostNames          = var.host_names
     }
   }
+  ignore_body_changes = length(var.ignore_body_changes.web_certificates) > 0 ? var.ignore_body_changes.web_certificates : null
   response_export_values = [
     "properties.thumbprint",
     "properties.expirationDate",
@@ -22,6 +23,17 @@ resource "azapi_resource" "this" {
   ]
   retry = var.retry
   tags  = var.tags
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 
   lifecycle {
     precondition {

--- a/modules/certificate/terraform.tf
+++ b/modules/certificate/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
   }
 }

--- a/modules/certificate/variables.tf
+++ b/modules/certificate/variables.tf
@@ -66,18 +66,68 @@ variable "pfx_blob" {
   sensitive   = true
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    web_certificates = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+- `web_certificates` - Paths ignored on the certificate.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "resource_types" {
+  type = object({
+    web_certificates = optional(string, "Microsoft.Web/certificates@2025-03-01")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions used by this module.
+
+- `web_certificates` - Resource type and API version for the certificate.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "retry" {
   type = object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
   })
-  default     = null
-  description = "(Optional) Retry configuration for the underlying azapi resource."
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+DESCRIPTION
 }
 
 variable "tags" {
   type        = map(string)
   default     = null
   description = "(Optional) Tags applied to the certificate resource."
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+DESCRIPTION
 }

--- a/modules/config_appsettings/README.md
+++ b/modules/config_appsettings/README.md
@@ -13,7 +13,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 ## Resources
 
@@ -42,6 +42,25 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_config` - Paths ignored on the app settings on a site.
+- `web_sites_slots_config` - Paths ignored on the app settings on a slot.
+
+Type:
+
+```hcl
+object({
+    web_sites_config       = optional(list(string), [])
+    web_sites_slots_config = optional(list(string), [])
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_is_slot"></a> [is\_slot](#input\_is\_slot)
 
 Description: Whether the parent resource is a deployment slot. Defaults to `false`.
@@ -50,29 +69,65 @@ Type: `bool`
 
 Default: `false`
 
-### <a name="input_retry"></a> [retry](#input\_retry)
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
 
-Description: Retry configuration for azapi resources.
+Description: AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the app settings on a site.
+- `web_sites_slots_config` - Resource type and API version for the app settings on a slot.
 
 Type:
 
 ```hcl
 object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    web_sites_config       = optional(string, "Microsoft.Web/sites/config@2025-03-01")
+    web_sites_slots_config = optional(string, "Microsoft.Web/sites/slots/config@2025-03-01")
   })
 ```
 
-Default:
+Default: `{}`
 
-```json
-{
-  "error_message_regex": [
-    "Cannot modify this site because another operation is in progress"
-  ]
-}
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
 ```
+
+Default: `{}`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
+
+Default: `null`
 
 ## Outputs
 

--- a/modules/config_appsettings/README.md
+++ b/modules/config_appsettings/README.md
@@ -46,7 +46,7 @@ The following input variables are optional (have default values):
 
 Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_config` - Paths ignored on the app settings on a site.
 - `web_sites_slots_config` - Paths ignored on the app settings on a slot.
 

--- a/modules/config_appsettings/locals.tf
+++ b/modules/config_appsettings/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  type = var.is_slot ? "Microsoft.Web/sites/slots/config@2025-03-01" : "Microsoft.Web/sites/config@2025-03-01"
+  type = var.is_slot ? var.resource_types.web_sites_slots_config : var.resource_types.web_sites_config
 }

--- a/modules/config_appsettings/main.tf
+++ b/modules/config_appsettings/main.tf
@@ -18,4 +18,11 @@ resource "azapi_update_resource" "this" {
       update = timeouts.value.update
     }
   }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.ignore_body_changes.web_sites_config) == 0 && length(var.ignore_body_changes.web_sites_slots_config) == 0
+      error_message = "`ignore_body_changes` is not supported here. This module manages its resource with `azapi_update_resource`, which the AzAPI provider does not give an `ignore_body_changes` argument, so any value set would be silently ignored."
+    }
+  }
 }

--- a/modules/config_appsettings/main.tf
+++ b/modules/config_appsettings/main.tf
@@ -7,4 +7,15 @@ resource "azapi_update_resource" "this" {
   }
   response_export_values = []
   retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }

--- a/modules/config_appsettings/terraform.tf
+++ b/modules/config_appsettings/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
   }
 }

--- a/modules/config_appsettings/variables.tf
+++ b/modules/config_appsettings/variables.tf
@@ -33,7 +33,7 @@ variable "ignore_body_changes" {
   description = <<DESCRIPTION
 Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_config` - Paths ignored on the app settings on a site.
 - `web_sites_slots_config` - Paths ignored on the app settings on a slot.
 DESCRIPTION

--- a/modules/config_appsettings/variables.tf
+++ b/modules/config_appsettings/variables.tf
@@ -24,14 +24,67 @@ variable "is_slot" {
   description = "Whether the parent resource is a deployment slot. Defaults to `false`."
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    web_sites_config       = optional(list(string), [])
+    web_sites_slots_config = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_config` - Paths ignored on the app settings on a site.
+- `web_sites_slots_config` - Paths ignored on the app settings on a slot.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "resource_types" {
+  type = object({
+    web_sites_config       = optional(string, "Microsoft.Web/sites/config@2025-03-01")
+    web_sites_slots_config = optional(string, "Microsoft.Web/sites/slots/config@2025-03-01")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the app settings on a site.
+- `web_sites_slots_config` - Resource type and API version for the app settings on a slot.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "retry" {
   type = object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
   })
-  default = {
-    error_message_regex = ["Cannot modify this site because another operation is in progress"]
-  }
-  description = "Retry configuration for azapi resources."
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+DESCRIPTION
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+DESCRIPTION
 }

--- a/modules/config_authsettings/README.md
+++ b/modules/config_authsettings/README.md
@@ -162,7 +162,7 @@ Default: `null`
 
 Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_config` - Paths ignored on the v1 auth settings.
 
 Type:

--- a/modules/config_authsettings/README.md
+++ b/modules/config_authsettings/README.md
@@ -15,7 +15,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 ## Resources
 
@@ -158,6 +158,23 @@ object({
 
 Default: `null`
 
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_config` - Paths ignored on the v1 auth settings.
+
+Type:
+
+```hcl
+object({
+    web_sites_config = optional(list(string), [])
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_issuer"></a> [issuer](#input\_issuer)
 
 Description: The issuer URI.
@@ -188,35 +205,69 @@ object({
 
 Default: `null`
 
-### <a name="input_retry"></a> [retry](#input\_retry)
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
 
-Description: Retry configuration for azapi resources.
+Description: AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the v1 auth settings.
 
 Type:
 
 ```hcl
 object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    web_sites_config = optional(string, "Microsoft.Web/sites/config@2025-03-01")
   })
 ```
 
-Default:
+Default: `{}`
 
-```json
-{
-  "error_message_regex": [
-    "Cannot modify this site because another operation is in progress"
-  ]
-}
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
 ```
+
+Default: `{}`
 
 ### <a name="input_runtime_version"></a> [runtime\_version](#input\_runtime\_version)
 
 Description: The runtime version of the authentication module.
 
 Type: `string`
+
+Default: `null`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
 
 Default: `null`
 

--- a/modules/config_authsettings/main.tf
+++ b/modules/config_authsettings/main.tf
@@ -5,7 +5,7 @@
 resource "azapi_update_resource" "this" {
   name      = "authsettings"
   parent_id = var.parent_id
-  type      = "Microsoft.Web/sites/config@2025-03-01"
+  type      = var.resource_types.web_sites_config
   body = {
     properties = {
       enabled                     = var.enabled
@@ -50,4 +50,15 @@ resource "azapi_update_resource" "this" {
   }
   response_export_values = []
   retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }

--- a/modules/config_authsettings/main.tf
+++ b/modules/config_authsettings/main.tf
@@ -61,4 +61,11 @@ resource "azapi_update_resource" "this" {
       update = timeouts.value.update
     }
   }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.ignore_body_changes.web_sites_config) == 0
+      error_message = "`ignore_body_changes` is not supported here. This module manages its resource with `azapi_update_resource`, which the AzAPI provider does not give an `ignore_body_changes` argument, so any value set would be silently ignored."
+    }
+  }
 }

--- a/modules/config_authsettings/terraform.tf
+++ b/modules/config_authsettings/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
   }
 }

--- a/modules/config_authsettings/variables.tf
+++ b/modules/config_authsettings/variables.tf
@@ -129,16 +129,47 @@ Microsoft authentication configuration.
 DESCRIPTION
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    web_sites_config = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_config` - Paths ignored on the v1 auth settings.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "resource_types" {
+  type = object({
+    web_sites_config = optional(string, "Microsoft.Web/sites/config@2025-03-01")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the v1 auth settings.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "retry" {
   type = object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
   })
-  default = {
-    error_message_regex = ["Cannot modify this site because another operation is in progress"]
-  }
-  description = "Retry configuration for azapi resources."
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+DESCRIPTION
 }
 
 variable "runtime_version" {
@@ -147,6 +178,23 @@ variable "runtime_version" {
   description = "The runtime version of the authentication module."
 }
 
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+DESCRIPTION
+}
 variable "token_refresh_extension_hours" {
   type        = number
   default     = 72

--- a/modules/config_authsettings/variables.tf
+++ b/modules/config_authsettings/variables.tf
@@ -137,7 +137,7 @@ variable "ignore_body_changes" {
   description = <<DESCRIPTION
 Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_config` - Paths ignored on the v1 auth settings.
 DESCRIPTION
   nullable    = false

--- a/modules/config_authsettingsv2/README.md
+++ b/modules/config_authsettingsv2/README.md
@@ -13,7 +13,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 ## Resources
 
@@ -315,6 +315,23 @@ object({
 
 Default: `null`
 
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_config` - Paths ignored on the v2 auth settings.
+
+Type:
+
+```hcl
+object({
+    web_sites_config = optional(list(string), [])
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_login"></a> [login](#input\_login)
 
 Description: Login configuration for auth settings V2. Mirrors the API structure of `login`.
@@ -393,29 +410,41 @@ Type: `bool`
 
 Default: `true`
 
-### <a name="input_retry"></a> [retry](#input\_retry)
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
 
-Description: Retry configuration for azapi resources.
+Description: AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the v2 auth settings.
 
 Type:
 
 ```hcl
 object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    web_sites_config = optional(string, "Microsoft.Web/sites/config@2025-03-01")
   })
 ```
 
-Default:
+Default: `{}`
 
-```json
-{
-  "error_message_regex": [
-    "Cannot modify this site because another operation is in progress"
-  ]
-}
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
 ```
+
+Default: `{}`
 
 ### <a name="input_runtime_version"></a> [runtime\_version](#input\_runtime\_version)
 
@@ -424,6 +453,28 @@ Description: The runtime version of the auth module. Defaults to `~1`.
 Type: `string`
 
 Default: `"~1"`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
+
+Default: `null`
 
 ### <a name="input_unauthenticated_client_action"></a> [unauthenticated\_client\_action](#input\_unauthenticated\_client\_action)
 

--- a/modules/config_authsettingsv2/README.md
+++ b/modules/config_authsettingsv2/README.md
@@ -319,7 +319,7 @@ Default: `null`
 
 Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_config` - Paths ignored on the v2 auth settings.
 
 Type:

--- a/modules/config_authsettingsv2/main.tf
+++ b/modules/config_authsettingsv2/main.tf
@@ -37,4 +37,11 @@ resource "azapi_update_resource" "this" {
       update = timeouts.value.update
     }
   }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.ignore_body_changes.web_sites_config) == 0
+      error_message = "`ignore_body_changes` is not supported here. This module manages its resource with `azapi_update_resource`, which the AzAPI provider does not give an `ignore_body_changes` argument, so any value set would be silently ignored."
+    }
+  }
 }

--- a/modules/config_authsettingsv2/main.tf
+++ b/modules/config_authsettingsv2/main.tf
@@ -1,7 +1,7 @@
 resource "azapi_update_resource" "this" {
   name      = "authsettingsV2"
   parent_id = var.parent_id
-  type      = "Microsoft.Web/sites/config@2025-03-01"
+  type      = var.resource_types.web_sites_config
   body = {
     properties = merge(
       {
@@ -26,4 +26,15 @@ resource "azapi_update_resource" "this" {
   }
   response_export_values = []
   retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }

--- a/modules/config_authsettingsv2/terraform.tf
+++ b/modules/config_authsettingsv2/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
   }
 }

--- a/modules/config_authsettingsv2/variables.tf
+++ b/modules/config_authsettingsv2/variables.tf
@@ -338,16 +338,47 @@ variable "require_https" {
   description = "Should HTTPS be required? Defaults to `true`."
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    web_sites_config = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_config` - Paths ignored on the v2 auth settings.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "resource_types" {
+  type = object({
+    web_sites_config = optional(string, "Microsoft.Web/sites/config@2025-03-01")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the v2 auth settings.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "retry" {
   type = object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
   })
-  default = {
-    error_message_regex = ["Cannot modify this site because another operation is in progress"]
-  }
-  description = "Retry configuration for azapi resources."
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+DESCRIPTION
 }
 
 variable "runtime_version" {
@@ -356,6 +387,23 @@ variable "runtime_version" {
   description = "The runtime version of the auth module. Defaults to `~1`."
 }
 
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+DESCRIPTION
+}
 variable "unauthenticated_client_action" {
   type        = string
   default     = "RedirectToLoginPage"

--- a/modules/config_authsettingsv2/variables.tf
+++ b/modules/config_authsettingsv2/variables.tf
@@ -346,7 +346,7 @@ variable "ignore_body_changes" {
   description = <<DESCRIPTION
 Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_config` - Paths ignored on the v2 auth settings.
 DESCRIPTION
   nullable    = false

--- a/modules/config_azurestorageaccounts/README.md
+++ b/modules/config_azurestorageaccounts/README.md
@@ -13,7 +13,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 ## Resources
 
@@ -60,6 +60,25 @@ map(object({
 
 The following input variables are optional (have default values):
 
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites` - Paths ignored on the storage account mounts on a site.
+- `web_sites_slots` - Paths ignored on the storage account mounts on a slot.
+
+Type:
+
+```hcl
+object({
+    web_sites       = optional(list(string), [])
+    web_sites_slots = optional(list(string), [])
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_is_slot"></a> [is\_slot](#input\_is\_slot)
 
 Description: Whether the parent resource is a deployment slot. Defaults to `false`.
@@ -68,29 +87,65 @@ Type: `bool`
 
 Default: `false`
 
-### <a name="input_retry"></a> [retry](#input\_retry)
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
 
-Description: Retry configuration for azapi resources.
+Description: AzAPI resource types and API versions used by this module.
+
+- `web_sites` - Resource type and API version for the storage account mounts on a site.
+- `web_sites_slots` - Resource type and API version for the storage account mounts on a slot.
 
 Type:
 
 ```hcl
 object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    web_sites       = optional(string, "Microsoft.Web/sites@2025-03-01")
+    web_sites_slots = optional(string, "Microsoft.Web/sites/slots@2025-03-01")
   })
 ```
 
-Default:
+Default: `{}`
 
-```json
-{
-  "error_message_regex": [
-    "Cannot modify this site because another operation is in progress"
-  ]
-}
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
 ```
+
+Default: `{}`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
+
+Default: `null`
 
 ## Outputs
 

--- a/modules/config_azurestorageaccounts/README.md
+++ b/modules/config_azurestorageaccounts/README.md
@@ -64,7 +64,7 @@ The following input variables are optional (have default values):
 
 Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites` - Paths ignored on the storage account mounts on a site.
 - `web_sites_slots` - Paths ignored on the storage account mounts on a slot.
 

--- a/modules/config_azurestorageaccounts/locals.tf
+++ b/modules/config_azurestorageaccounts/locals.tf
@@ -6,5 +6,5 @@ locals {
     mountPath   = v.mount_path
     accessKey   = v.access_key
   } }
-  type = var.is_slot ? "Microsoft.Web/sites/slots@2025-03-01" : "Microsoft.Web/sites@2025-03-01"
+  type = var.is_slot ? var.resource_types.web_sites_slots : var.resource_types.web_sites
 }

--- a/modules/config_azurestorageaccounts/main.tf
+++ b/modules/config_azurestorageaccounts/main.tf
@@ -7,4 +7,15 @@ resource "azapi_resource_action" "this" {
     properties = local.storage_mounts
   }
   retry = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }

--- a/modules/config_azurestorageaccounts/main.tf
+++ b/modules/config_azurestorageaccounts/main.tf
@@ -18,4 +18,11 @@ resource "azapi_resource_action" "this" {
       update = timeouts.value.update
     }
   }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.ignore_body_changes.web_sites) == 0 && length(var.ignore_body_changes.web_sites_slots) == 0
+      error_message = "`ignore_body_changes` is not supported here. This module manages its resource with `azapi_resource_action`, which the AzAPI provider does not give an `ignore_body_changes` argument, so any value set would be silently ignored."
+    }
+  }
 }

--- a/modules/config_azurestorageaccounts/terraform.tf
+++ b/modules/config_azurestorageaccounts/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
   }
 }

--- a/modules/config_azurestorageaccounts/variables.tf
+++ b/modules/config_azurestorageaccounts/variables.tf
@@ -49,7 +49,7 @@ variable "ignore_body_changes" {
   description = <<DESCRIPTION
 Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites` - Paths ignored on the storage account mounts on a site.
 - `web_sites_slots` - Paths ignored on the storage account mounts on a slot.
 DESCRIPTION

--- a/modules/config_azurestorageaccounts/variables.tf
+++ b/modules/config_azurestorageaccounts/variables.tf
@@ -40,14 +40,67 @@ variable "is_slot" {
   description = "Whether the parent resource is a deployment slot. Defaults to `false`."
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    web_sites       = optional(list(string), [])
+    web_sites_slots = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites` - Paths ignored on the storage account mounts on a site.
+- `web_sites_slots` - Paths ignored on the storage account mounts on a slot.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "resource_types" {
+  type = object({
+    web_sites       = optional(string, "Microsoft.Web/sites@2025-03-01")
+    web_sites_slots = optional(string, "Microsoft.Web/sites/slots@2025-03-01")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions used by this module.
+
+- `web_sites` - Resource type and API version for the storage account mounts on a site.
+- `web_sites_slots` - Resource type and API version for the storage account mounts on a slot.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "retry" {
   type = object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
   })
-  default = {
-    error_message_regex = ["Cannot modify this site because another operation is in progress"]
-  }
-  description = "Retry configuration for azapi resources."
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+DESCRIPTION
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+DESCRIPTION
 }

--- a/modules/config_backup/README.md
+++ b/modules/config_backup/README.md
@@ -13,7 +13,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 ## Resources
 
@@ -52,29 +52,58 @@ Type: `bool`
 
 Default: `true`
 
-### <a name="input_retry"></a> [retry](#input\_retry)
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
 
-Description: Retry configuration for azapi resources.
+Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_config` - Paths ignored on the backup configuration.
 
 Type:
 
 ```hcl
 object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    web_sites_config = optional(list(string), [])
   })
 ```
 
-Default:
+Default: `{}`
 
-```json
-{
-  "error_message_regex": [
-    "Cannot modify this site because another operation is in progress"
-  ]
-}
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
+
+Description: AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the backup configuration.
+
+Type:
+
+```hcl
+object({
+    web_sites_config = optional(string, "Microsoft.Web/sites/config@2025-03-01")
+  })
 ```
+
+Default: `{}`
+
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
+```
+
+Default: `{}`
 
 ### <a name="input_schedule"></a> [schedule](#input\_schedule)
 
@@ -105,6 +134,28 @@ Default: `null`
 Description: The SAS URL to the Storage Account container for backup.
 
 Type: `string`
+
+Default: `null`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
 
 Default: `null`
 

--- a/modules/config_backup/README.md
+++ b/modules/config_backup/README.md
@@ -56,7 +56,7 @@ Default: `true`
 
 Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_config` - Paths ignored on the backup configuration.
 
 Type:

--- a/modules/config_backup/main.tf
+++ b/modules/config_backup/main.tf
@@ -29,4 +29,11 @@ resource "azapi_update_resource" "this" {
       update = timeouts.value.update
     }
   }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.ignore_body_changes.web_sites_config) == 0
+      error_message = "`ignore_body_changes` is not supported here. This module manages its resource with `azapi_update_resource`, which the AzAPI provider does not give an `ignore_body_changes` argument, so any value set would be silently ignored."
+    }
+  }
 }

--- a/modules/config_backup/main.tf
+++ b/modules/config_backup/main.tf
@@ -1,7 +1,7 @@
 resource "azapi_update_resource" "this" {
   name      = "backup"
   parent_id = var.parent_id
-  type      = "Microsoft.Web/sites/config@2025-03-01"
+  type      = var.resource_types.web_sites_config
   body = {
     properties = {
       backupName        = var.backup_name
@@ -18,4 +18,15 @@ resource "azapi_update_resource" "this" {
   }
   response_export_values = []
   retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }

--- a/modules/config_backup/terraform.tf
+++ b/modules/config_backup/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
   }
 }

--- a/modules/config_backup/variables.tf
+++ b/modules/config_backup/variables.tf
@@ -21,16 +21,47 @@ variable "enabled" {
   description = "Is backup enabled? Defaults to `true`."
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    web_sites_config = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_config` - Paths ignored on the backup configuration.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "resource_types" {
+  type = object({
+    web_sites_config = optional(string, "Microsoft.Web/sites/config@2025-03-01")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the backup configuration.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "retry" {
   type = object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
   })
-  default = {
-    error_message_regex = ["Cannot modify this site because another operation is in progress"]
-  }
-  description = "Retry configuration for azapi resources."
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+DESCRIPTION
 }
 
 variable "schedule" {
@@ -57,4 +88,22 @@ variable "storage_account_url" {
   type        = string
   default     = null
   description = "The SAS URL to the Storage Account container for backup."
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+DESCRIPTION
 }

--- a/modules/config_backup/variables.tf
+++ b/modules/config_backup/variables.tf
@@ -29,7 +29,7 @@ variable "ignore_body_changes" {
   description = <<DESCRIPTION
 Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_config` - Paths ignored on the backup configuration.
 DESCRIPTION
   nullable    = false

--- a/modules/config_connectionstrings/README.md
+++ b/modules/config_connectionstrings/README.md
@@ -58,7 +58,7 @@ The following input variables are optional (have default values):
 
 Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_config` - Paths ignored on the connection strings on a site.
 - `web_sites_slots_config` - Paths ignored on the connection strings on a slot.
 

--- a/modules/config_connectionstrings/README.md
+++ b/modules/config_connectionstrings/README.md
@@ -13,7 +13,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 ## Resources
 
@@ -54,6 +54,25 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_config` - Paths ignored on the connection strings on a site.
+- `web_sites_slots_config` - Paths ignored on the connection strings on a slot.
+
+Type:
+
+```hcl
+object({
+    web_sites_config       = optional(list(string), [])
+    web_sites_slots_config = optional(list(string), [])
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_is_slot"></a> [is\_slot](#input\_is\_slot)
 
 Description: Whether the parent resource is a deployment slot. Defaults to `false`.
@@ -62,29 +81,65 @@ Type: `bool`
 
 Default: `false`
 
-### <a name="input_retry"></a> [retry](#input\_retry)
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
 
-Description: Retry configuration for azapi resources.
+Description: AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the connection strings on a site.
+- `web_sites_slots_config` - Resource type and API version for the connection strings on a slot.
 
 Type:
 
 ```hcl
 object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    web_sites_config       = optional(string, "Microsoft.Web/sites/config@2025-03-01")
+    web_sites_slots_config = optional(string, "Microsoft.Web/sites/slots/config@2025-03-01")
   })
 ```
 
-Default:
+Default: `{}`
 
-```json
-{
-  "error_message_regex": [
-    "Cannot modify this site because another operation is in progress"
-  ]
-}
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
 ```
+
+Default: `{}`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
+
+Default: `null`
 
 ## Outputs
 

--- a/modules/config_connectionstrings/locals.tf
+++ b/modules/config_connectionstrings/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  type = var.is_slot ? "Microsoft.Web/sites/slots/config@2025-03-01" : "Microsoft.Web/sites/config@2025-03-01"
+  type = var.is_slot ? var.resource_types.web_sites_slots_config : var.resource_types.web_sites_config
 }

--- a/modules/config_connectionstrings/main.tf
+++ b/modules/config_connectionstrings/main.tf
@@ -21,4 +21,11 @@ resource "azapi_update_resource" "this" {
       update = timeouts.value.update
     }
   }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.ignore_body_changes.web_sites_config) == 0 && length(var.ignore_body_changes.web_sites_slots_config) == 0
+      error_message = "`ignore_body_changes` is not supported here. This module manages its resource with `azapi_update_resource`, which the AzAPI provider does not give an `ignore_body_changes` argument, so any value set would be silently ignored."
+    }
+  }
 }

--- a/modules/config_connectionstrings/main.tf
+++ b/modules/config_connectionstrings/main.tf
@@ -10,4 +10,15 @@ resource "azapi_update_resource" "this" {
   }
   response_export_values = []
   retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }

--- a/modules/config_connectionstrings/terraform.tf
+++ b/modules/config_connectionstrings/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
   }
 }

--- a/modules/config_connectionstrings/variables.tf
+++ b/modules/config_connectionstrings/variables.tf
@@ -43,7 +43,7 @@ variable "ignore_body_changes" {
   description = <<DESCRIPTION
 Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_config` - Paths ignored on the connection strings on a site.
 - `web_sites_slots_config` - Paths ignored on the connection strings on a slot.
 DESCRIPTION

--- a/modules/config_connectionstrings/variables.tf
+++ b/modules/config_connectionstrings/variables.tf
@@ -34,14 +34,67 @@ variable "is_slot" {
   description = "Whether the parent resource is a deployment slot. Defaults to `false`."
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    web_sites_config       = optional(list(string), [])
+    web_sites_slots_config = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_config` - Paths ignored on the connection strings on a site.
+- `web_sites_slots_config` - Paths ignored on the connection strings on a slot.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "resource_types" {
+  type = object({
+    web_sites_config       = optional(string, "Microsoft.Web/sites/config@2025-03-01")
+    web_sites_slots_config = optional(string, "Microsoft.Web/sites/slots/config@2025-03-01")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the connection strings on a site.
+- `web_sites_slots_config` - Resource type and API version for the connection strings on a slot.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "retry" {
   type = object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
   })
-  default = {
-    error_message_regex = ["Cannot modify this site because another operation is in progress"]
-  }
-  description = "Retry configuration for azapi resources."
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+DESCRIPTION
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+DESCRIPTION
 }

--- a/modules/config_logs/README.md
+++ b/modules/config_logs/README.md
@@ -13,7 +13,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 ## Resources
 
@@ -108,29 +108,80 @@ object({
 
 Default: `null`
 
-### <a name="input_retry"></a> [retry](#input\_retry)
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
 
-Description: Retry configuration for azapi resources.
+Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_config` - Paths ignored on the logs configuration.
 
 Type:
 
 ```hcl
 object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    web_sites_config = optional(list(string), [])
   })
 ```
 
-Default:
+Default: `{}`
 
-```json
-{
-  "error_message_regex": [
-    "Cannot modify this site because another operation is in progress"
-  ]
-}
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
+
+Description: AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the logs configuration.
+
+Type:
+
+```hcl
+object({
+    web_sites_config = optional(string, "Microsoft.Web/sites/config@2025-03-01")
+  })
 ```
+
+Default: `{}`
+
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
+```
+
+Default: `{}`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
+
+Default: `null`
 
 ## Outputs
 

--- a/modules/config_logs/README.md
+++ b/modules/config_logs/README.md
@@ -112,7 +112,7 @@ Default: `null`
 
 Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_config` - Paths ignored on the logs configuration.
 
 Type:

--- a/modules/config_logs/main.tf
+++ b/modules/config_logs/main.tf
@@ -60,4 +60,11 @@ resource "azapi_update_resource" "this" {
       update = timeouts.value.update
     }
   }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.ignore_body_changes.web_sites_config) == 0
+      error_message = "`ignore_body_changes` is not supported here. This module manages its resource with `azapi_update_resource`, which the AzAPI provider does not give an `ignore_body_changes` argument, so any value set would be silently ignored."
+    }
+  }
 }

--- a/modules/config_logs/main.tf
+++ b/modules/config_logs/main.tf
@@ -1,7 +1,7 @@
 resource "azapi_update_resource" "this" {
   name      = "logs"
   parent_id = var.parent_id
-  type      = "Microsoft.Web/sites/config@2025-03-01"
+  type      = var.resource_types.web_sites_config
   body = {
     properties = merge(
       {
@@ -49,4 +49,15 @@ resource "azapi_update_resource" "this" {
   }
   response_export_values = []
   retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }

--- a/modules/config_logs/terraform.tf
+++ b/modules/config_logs/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
   }
 }

--- a/modules/config_logs/variables.tf
+++ b/modules/config_logs/variables.tf
@@ -69,14 +69,63 @@ HTTP log settings.
 DESCRIPTION
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    web_sites_config = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_config` - Paths ignored on the logs configuration.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "resource_types" {
+  type = object({
+    web_sites_config = optional(string, "Microsoft.Web/sites/config@2025-03-01")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the logs configuration.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "retry" {
   type = object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
   })
-  default = {
-    error_message_regex = ["Cannot modify this site because another operation is in progress"]
-  }
-  description = "Retry configuration for azapi resources."
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+DESCRIPTION
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+DESCRIPTION
 }

--- a/modules/config_logs/variables.tf
+++ b/modules/config_logs/variables.tf
@@ -77,7 +77,7 @@ variable "ignore_body_changes" {
   description = <<DESCRIPTION
 Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_config` - Paths ignored on the logs configuration.
 DESCRIPTION
   nullable    = false

--- a/modules/config_metadata/README.md
+++ b/modules/config_metadata/README.md
@@ -13,7 +13,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 ## Resources
 
@@ -42,6 +42,25 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_config` - Paths ignored on the site metadata on a site.
+- `web_sites_slots_config` - Paths ignored on the site metadata on a slot.
+
+Type:
+
+```hcl
+object({
+    web_sites_config       = optional(list(string), [])
+    web_sites_slots_config = optional(list(string), [])
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_is_slot"></a> [is\_slot](#input\_is\_slot)
 
 Description: Whether the parent resource is a deployment slot. Defaults to `false`.
@@ -50,29 +69,65 @@ Type: `bool`
 
 Default: `false`
 
-### <a name="input_retry"></a> [retry](#input\_retry)
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
 
-Description: Retry configuration for azapi resources.
+Description: AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the site metadata on a site.
+- `web_sites_slots_config` - Resource type and API version for the site metadata on a slot.
 
 Type:
 
 ```hcl
 object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    web_sites_config       = optional(string, "Microsoft.Web/sites/config@2025-03-01")
+    web_sites_slots_config = optional(string, "Microsoft.Web/sites/slots/config@2025-03-01")
   })
 ```
 
-Default:
+Default: `{}`
 
-```json
-{
-  "error_message_regex": [
-    "Cannot modify this site because another operation is in progress"
-  ]
-}
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
 ```
+
+Default: `{}`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
+
+Default: `null`
 
 ## Outputs
 

--- a/modules/config_metadata/README.md
+++ b/modules/config_metadata/README.md
@@ -46,7 +46,7 @@ The following input variables are optional (have default values):
 
 Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_config` - Paths ignored on the site metadata on a site.
 - `web_sites_slots_config` - Paths ignored on the site metadata on a slot.
 

--- a/modules/config_metadata/locals.tf
+++ b/modules/config_metadata/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  type = var.is_slot ? "Microsoft.Web/sites/slots/config@2025-03-01" : "Microsoft.Web/sites/config@2025-03-01"
+  type = var.is_slot ? var.resource_types.web_sites_slots_config : var.resource_types.web_sites_config
 }

--- a/modules/config_metadata/main.tf
+++ b/modules/config_metadata/main.tf
@@ -6,4 +6,15 @@ resource "azapi_resource_action" "this" {
     properties = var.metadata
   }
   retry = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }

--- a/modules/config_metadata/main.tf
+++ b/modules/config_metadata/main.tf
@@ -17,4 +17,11 @@ resource "azapi_resource_action" "this" {
       update = timeouts.value.update
     }
   }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.ignore_body_changes.web_sites_config) == 0 && length(var.ignore_body_changes.web_sites_slots_config) == 0
+      error_message = "`ignore_body_changes` is not supported here. This module manages its resource with `azapi_resource_action`, which the AzAPI provider does not give an `ignore_body_changes` argument, so any value set would be silently ignored."
+    }
+  }
 }

--- a/modules/config_metadata/terraform.tf
+++ b/modules/config_metadata/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
   }
 }

--- a/modules/config_metadata/variables.tf
+++ b/modules/config_metadata/variables.tf
@@ -24,14 +24,67 @@ variable "is_slot" {
   description = "Whether the parent resource is a deployment slot. Defaults to `false`."
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    web_sites_config       = optional(list(string), [])
+    web_sites_slots_config = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_config` - Paths ignored on the site metadata on a site.
+- `web_sites_slots_config` - Paths ignored on the site metadata on a slot.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "resource_types" {
+  type = object({
+    web_sites_config       = optional(string, "Microsoft.Web/sites/config@2025-03-01")
+    web_sites_slots_config = optional(string, "Microsoft.Web/sites/slots/config@2025-03-01")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the site metadata on a site.
+- `web_sites_slots_config` - Resource type and API version for the site metadata on a slot.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "retry" {
   type = object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
   })
-  default = {
-    error_message_regex = ["Cannot modify this site because another operation is in progress"]
-  }
-  description = "Retry configuration for azapi resources."
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+DESCRIPTION
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+DESCRIPTION
 }

--- a/modules/config_metadata/variables.tf
+++ b/modules/config_metadata/variables.tf
@@ -33,7 +33,7 @@ variable "ignore_body_changes" {
   description = <<DESCRIPTION
 Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_config` - Paths ignored on the site metadata on a site.
 - `web_sites_slots_config` - Paths ignored on the site metadata on a slot.
 DESCRIPTION

--- a/modules/config_slotconfignames/README.md
+++ b/modules/config_slotconfignames/README.md
@@ -13,7 +13,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 ## Resources
 
@@ -52,29 +52,81 @@ Type: `list(string)`
 
 Default: `[]`
 
-### <a name="input_retry"></a> [retry](#input\_retry)
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
 
-Description: Retry configuration for azapi resources.
+Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with `azapi_update_resource`, so the variable is declared for interface consistency and is not applied yet.
+
+- `web_sites_config` - Paths ignored on the slot config names resource.
 
 Type:
 
 ```hcl
 object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    web_sites_config = optional(list(string), [])
   })
 ```
 
-Default:
+Default: `{}`
 
-```json
-{
-  "error_message_regex": [
-    "Cannot modify this site because another operation is in progress"
-  ]
-}
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
+
+Description: AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the slot config names resource.
+
+Type:
+
+```hcl
+object({
+    web_sites_config = optional(string, "Microsoft.Web/sites/config@2025-03-01")
+  })
 ```
+
+Default: `{}`
+
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
+```
+
+Default: `{}`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
+
+Default: `null`
 
 ## Outputs
 

--- a/modules/config_slotconfignames/README.md
+++ b/modules/config_slotconfignames/README.md
@@ -56,7 +56,7 @@ Default: `[]`
 
 Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with `azapi_update_resource`, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with `azapi_update_resource`. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 
 - `web_sites_config` - Paths ignored on the slot config names resource.
 

--- a/modules/config_slotconfignames/main.tf
+++ b/modules/config_slotconfignames/main.tf
@@ -1,7 +1,7 @@
 resource "azapi_update_resource" "this" {
   name      = "slotConfigNames"
   parent_id = var.parent_id
-  type      = "Microsoft.Web/sites/config@2025-03-01"
+  type      = var.resource_types.web_sites_config
   body = {
     properties = {
       appSettingNames       = var.app_setting_names
@@ -10,4 +10,15 @@ resource "azapi_update_resource" "this" {
   }
   response_export_values = []
   retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }

--- a/modules/config_slotconfignames/main.tf
+++ b/modules/config_slotconfignames/main.tf
@@ -21,4 +21,11 @@ resource "azapi_update_resource" "this" {
       update = timeouts.value.update
     }
   }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.ignore_body_changes.web_sites_config) == 0
+      error_message = "`ignore_body_changes` is not supported here. This module manages its resource with `azapi_update_resource`, which the AzAPI provider does not give an `ignore_body_changes` argument, so any value set would be silently ignored."
+    }
+  }
 }

--- a/modules/config_slotconfignames/terraform.tf
+++ b/modules/config_slotconfignames/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
   }
 }

--- a/modules/config_slotconfignames/variables.tf
+++ b/modules/config_slotconfignames/variables.tf
@@ -21,14 +21,64 @@ variable "connection_string_names" {
   description = "A list of connection string names that should be sticky (not swapped during slot swaps)."
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    web_sites_config = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with `azapi_update_resource`, so the variable is declared for interface consistency and is not applied yet.
+
+- `web_sites_config` - Paths ignored on the slot config names resource.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "resource_types" {
+  type = object({
+    web_sites_config = optional(string, "Microsoft.Web/sites/config@2025-03-01")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions used by this module.
+
+- `web_sites_config` - Resource type and API version for the slot config names resource.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "retry" {
   type = object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
   })
-  default = {
-    error_message_regex = ["Cannot modify this site because another operation is in progress"]
-  }
-  description = "Retry configuration for azapi resources."
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+DESCRIPTION
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+DESCRIPTION
 }

--- a/modules/config_slotconfignames/variables.tf
+++ b/modules/config_slotconfignames/variables.tf
@@ -29,7 +29,7 @@ variable "ignore_body_changes" {
   description = <<DESCRIPTION
 Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with `azapi_update_resource`, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with `azapi_update_resource`. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 
 - `web_sites_config` - Paths ignored on the slot config names resource.
 DESCRIPTION

--- a/modules/extensions_zipdeploy/README.md
+++ b/modules/extensions_zipdeploy/README.md
@@ -13,7 +13,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 ## Resources
 
@@ -42,6 +42,25 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites` - Paths ignored on the zip deployment on a site.
+- `web_sites_slots` - Paths ignored on the zip deployment on a slot.
+
+Type:
+
+```hcl
+object({
+    web_sites       = optional(list(string), [])
+    web_sites_slots = optional(list(string), [])
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_is_slot"></a> [is\_slot](#input\_is\_slot)
 
 Description: Whether the parent resource is a deployment slot. Defaults to `false`.
@@ -50,29 +69,65 @@ Type: `bool`
 
 Default: `false`
 
-### <a name="input_retry"></a> [retry](#input\_retry)
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
 
-Description: Retry configuration for azapi resources.
+Description: AzAPI resource types and API versions used by this module.
+
+- `web_sites` - Resource type and API version for the zip deployment on a site.
+- `web_sites_slots` - Resource type and API version for the zip deployment on a slot.
 
 Type:
 
 ```hcl
 object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    web_sites       = optional(string, "Microsoft.Web/sites@2025-03-01")
+    web_sites_slots = optional(string, "Microsoft.Web/sites/slots@2025-03-01")
   })
 ```
 
-Default:
+Default: `{}`
 
-```json
-{
-  "error_message_regex": [
-    "Cannot modify this site because another operation is in progress"
-  ]
-}
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
 ```
+
+Default: `{}`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
+
+Default: `null`
 
 ## Outputs
 

--- a/modules/extensions_zipdeploy/README.md
+++ b/modules/extensions_zipdeploy/README.md
@@ -46,7 +46,7 @@ The following input variables are optional (have default values):
 
 Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites` - Paths ignored on the zip deployment on a site.
 - `web_sites_slots` - Paths ignored on the zip deployment on a slot.
 

--- a/modules/extensions_zipdeploy/locals.tf
+++ b/modules/extensions_zipdeploy/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  type = var.is_slot ? "Microsoft.Web/sites/slots@2025-03-01" : "Microsoft.Web/sites@2025-03-01"
+  type = var.is_slot ? var.resource_types.web_sites_slots : var.resource_types.web_sites
 }

--- a/modules/extensions_zipdeploy/main.tf
+++ b/modules/extensions_zipdeploy/main.tf
@@ -24,5 +24,10 @@ resource "azapi_resource_action" "this" {
 
   lifecycle {
     ignore_changes = [body]
+
+    precondition {
+      condition     = length(var.ignore_body_changes.web_sites) == 0 && length(var.ignore_body_changes.web_sites_slots) == 0
+      error_message = "`ignore_body_changes` is not supported here. This module manages its resource with `azapi_resource_action`, which the AzAPI provider does not give an `ignore_body_changes` argument, so any value set would be silently ignored."
+    }
   }
 }

--- a/modules/extensions_zipdeploy/main.tf
+++ b/modules/extensions_zipdeploy/main.tf
@@ -11,6 +11,17 @@ resource "azapi_resource_action" "this" {
   }
   retry = var.retry
 
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
+
   lifecycle {
     ignore_changes = [body]
   }

--- a/modules/extensions_zipdeploy/terraform.tf
+++ b/modules/extensions_zipdeploy/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
   }
 }

--- a/modules/extensions_zipdeploy/variables.tf
+++ b/modules/extensions_zipdeploy/variables.tf
@@ -33,7 +33,7 @@ variable "ignore_body_changes" {
   description = <<DESCRIPTION
 Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites` - Paths ignored on the zip deployment on a site.
 - `web_sites_slots` - Paths ignored on the zip deployment on a slot.
 DESCRIPTION

--- a/modules/extensions_zipdeploy/variables.tf
+++ b/modules/extensions_zipdeploy/variables.tf
@@ -24,14 +24,67 @@ variable "is_slot" {
   description = "Whether the parent resource is a deployment slot. Defaults to `false`."
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    web_sites       = optional(list(string), [])
+    web_sites_slots = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites` - Paths ignored on the zip deployment on a site.
+- `web_sites_slots` - Paths ignored on the zip deployment on a slot.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "resource_types" {
+  type = object({
+    web_sites       = optional(string, "Microsoft.Web/sites@2025-03-01")
+    web_sites_slots = optional(string, "Microsoft.Web/sites/slots@2025-03-01")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions used by this module.
+
+- `web_sites` - Resource type and API version for the zip deployment on a site.
+- `web_sites_slots` - Resource type and API version for the zip deployment on a slot.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "retry" {
   type = object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
   })
-  default = {
-    error_message_regex = ["Cannot modify this site because another operation is in progress"]
-  }
-  description = "Retry configuration for azapi resources."
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+DESCRIPTION
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+DESCRIPTION
 }

--- a/modules/hostname_binding/README.md
+++ b/modules/hostname_binding/README.md
@@ -13,7 +13,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 ## Resources
 
@@ -42,33 +42,61 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
-### <a name="input_retry"></a> [retry](#input\_retry)
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
 
-Description: Retry configuration for azapi resources. By default, retries on transient site lock errors and on the DNS / hostname validation errors that surface while custom domain ownership records are still propagating.
+Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+- `web_sites_host_name_bindings` - Paths ignored on the hostname binding on a site.
+- `web_sites_slots_host_name_bindings` - Paths ignored on the hostname binding on a slot.
 
 Type:
 
 ```hcl
 object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    web_sites_host_name_bindings       = optional(list(string), [])
+    web_sites_slots_host_name_bindings = optional(list(string), [])
   })
 ```
 
-Default:
+Default: `{}`
 
-```json
-{
-  "error_message_regex": [
-    "Cannot modify this site because another operation is in progress",
-    "A CNAME record pointing from .* was not found",
-    "A TXT record pointing from asuid\\..* was not found",
-    "Hostname .* does not resolve to the controller IP address",
-    "Validation failed for a hostname"
-  ]
-}
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
+
+Description: AzAPI resource types and API versions used by this module.
+
+- `web_sites_host_name_bindings` - Resource type and API version for the hostname binding on a site.
+- `web_sites_slots_host_name_bindings` - Resource type and API version for the hostname binding on a slot.
+
+Type:
+
+```hcl
+object({
+    web_sites_host_name_bindings       = optional(string, "Microsoft.Web/sites/hostNameBindings@2025-03-01")
+    web_sites_slots_host_name_bindings = optional(string, "Microsoft.Web/sites/slots/hostNameBindings@2025-03-01")
+  })
 ```
+
+Default: `{}`
+
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
+```
+
+Default: `{}`
 
 ### <a name="input_ssl_state"></a> [ssl\_state](#input\_ssl\_state)
 
@@ -83,6 +111,28 @@ Default: `null`
 Description: The certificate thumbprint associated with the hostname.
 
 Type: `string`
+
+Default: `null`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
 
 Default: `null`
 

--- a/modules/hostname_binding/locals.tf
+++ b/modules/hostname_binding/locals.tf
@@ -1,5 +1,6 @@
 locals {
   # Determine the ARM type based on whether the parent is a site or a slot
-  is_slot = can(regex("/slots/", var.parent_id))
-  type    = local.is_slot ? "Microsoft.Web/sites/slots/hostNameBindings@2025-03-01" : "Microsoft.Web/sites/hostNameBindings@2025-03-01"
+  ignore_body_changes = local.is_slot ? var.ignore_body_changes.web_sites_slots_host_name_bindings : var.ignore_body_changes.web_sites_host_name_bindings
+  is_slot             = can(regex("/slots/", var.parent_id))
+  type                = local.is_slot ? var.resource_types.web_sites_slots_host_name_bindings : var.resource_types.web_sites_host_name_bindings
 }

--- a/modules/hostname_binding/main.tf
+++ b/modules/hostname_binding/main.tf
@@ -8,6 +8,18 @@ resource "azapi_resource" "this" {
       thumbprint = var.thumbprint
     }
   }
+  ignore_body_changes    = length(local.ignore_body_changes) > 0 ? local.ignore_body_changes : null
   response_export_values = []
   retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }

--- a/modules/hostname_binding/terraform.tf
+++ b/modules/hostname_binding/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
   }
 }

--- a/modules/hostname_binding/variables.tf
+++ b/modules/hostname_binding/variables.tf
@@ -18,25 +18,50 @@ variable "parent_id" {
   }
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    web_sites_host_name_bindings       = optional(list(string), [])
+    web_sites_slots_host_name_bindings = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+- `web_sites_host_name_bindings` - Paths ignored on the hostname binding on a site.
+- `web_sites_slots_host_name_bindings` - Paths ignored on the hostname binding on a slot.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "resource_types" {
+  type = object({
+    web_sites_host_name_bindings       = optional(string, "Microsoft.Web/sites/hostNameBindings@2025-03-01")
+    web_sites_slots_host_name_bindings = optional(string, "Microsoft.Web/sites/slots/hostNameBindings@2025-03-01")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions used by this module.
+
+- `web_sites_host_name_bindings` - Resource type and API version for the hostname binding on a site.
+- `web_sites_slots_host_name_bindings` - Resource type and API version for the hostname binding on a slot.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "retry" {
   type = object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
   })
-  default = {
-    error_message_regex = [
-      "Cannot modify this site because another operation is in progress",
-      # Domain ownership validation is asynchronous on Azure's side; the binding
-      # call can race ahead of DNS / verification record propagation. Retry
-      # while validation is still in flight.
-      "A CNAME record pointing from .* was not found",
-      "A TXT record pointing from asuid\\..* was not found",
-      "Hostname .* does not resolve to the controller IP address",
-      "Validation failed for a hostname",
-    ]
-  }
-  description = "Retry configuration for azapi resources. By default, retries on transient site lock errors and on the DNS / hostname validation errors that surface while custom domain ownership records are still propagating."
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+DESCRIPTION
 }
 
 variable "ssl_state" {
@@ -49,4 +74,22 @@ variable "thumbprint" {
   type        = string
   default     = null
   description = "The certificate thumbprint associated with the hostname."
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+DESCRIPTION
 }

--- a/modules/publishing_credential_policy/README.md
+++ b/modules/publishing_credential_policy/README.md
@@ -13,7 +13,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 ## Resources
 
@@ -50,6 +50,25 @@ Type: `bool`
 
 Default: `false`
 
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_basic_publishing_credentials_policies` - Paths ignored on the publishing credential policy on a site.
+- `web_sites_slots_basic_publishing_credentials_policies` - Paths ignored on the publishing credential policy on a slot.
+
+Type:
+
+```hcl
+object({
+    web_sites_basic_publishing_credentials_policies       = optional(list(string), [])
+    web_sites_slots_basic_publishing_credentials_policies = optional(list(string), [])
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_is_slot"></a> [is\_slot](#input\_is\_slot)
 
 Description: Whether the parent resource is a deployment slot. Defaults to `false`.
@@ -58,29 +77,65 @@ Type: `bool`
 
 Default: `false`
 
-### <a name="input_retry"></a> [retry](#input\_retry)
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
 
-Description: Retry configuration for azapi resources.
+Description: AzAPI resource types and API versions used by this module.
+
+- `web_sites_basic_publishing_credentials_policies` - Resource type and API version for the publishing credential policy on a site.
+- `web_sites_slots_basic_publishing_credentials_policies` - Resource type and API version for the publishing credential policy on a slot.
 
 Type:
 
 ```hcl
 object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    web_sites_basic_publishing_credentials_policies       = optional(string, "Microsoft.Web/sites/basicPublishingCredentialsPolicies@2025-03-01")
+    web_sites_slots_basic_publishing_credentials_policies = optional(string, "Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies@2025-03-01")
   })
 ```
 
-Default:
+Default: `{}`
 
-```json
-{
-  "error_message_regex": [
-    "Cannot modify this site because another operation is in progress"
-  ]
-}
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
 ```
+
+Default: `{}`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
+
+Default: `null`
 
 ## Outputs
 

--- a/modules/publishing_credential_policy/README.md
+++ b/modules/publishing_credential_policy/README.md
@@ -54,7 +54,7 @@ Default: `false`
 
 Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_basic_publishing_credentials_policies` - Paths ignored on the publishing credential policy on a site.
 - `web_sites_slots_basic_publishing_credentials_policies` - Paths ignored on the publishing credential policy on a slot.
 

--- a/modules/publishing_credential_policy/locals.tf
+++ b/modules/publishing_credential_policy/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  type = var.is_slot ? "Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies@2025-03-01" : "Microsoft.Web/sites/basicPublishingCredentialsPolicies@2025-03-01"
+  type = var.is_slot ? var.resource_types.web_sites_slots_basic_publishing_credentials_policies : var.resource_types.web_sites_basic_publishing_credentials_policies
 }

--- a/modules/publishing_credential_policy/main.tf
+++ b/modules/publishing_credential_policy/main.tf
@@ -9,4 +9,15 @@ resource "azapi_update_resource" "this" {
   }
   response_export_values = []
   retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }

--- a/modules/publishing_credential_policy/main.tf
+++ b/modules/publishing_credential_policy/main.tf
@@ -20,4 +20,11 @@ resource "azapi_update_resource" "this" {
       update = timeouts.value.update
     }
   }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.ignore_body_changes.web_sites_basic_publishing_credentials_policies) == 0 && length(var.ignore_body_changes.web_sites_slots_basic_publishing_credentials_policies) == 0
+      error_message = "`ignore_body_changes` is not supported here. This module manages its resource with `azapi_update_resource`, which the AzAPI provider does not give an `ignore_body_changes` argument, so any value set would be silently ignored."
+    }
+  }
 }

--- a/modules/publishing_credential_policy/terraform.tf
+++ b/modules/publishing_credential_policy/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
   }
 }

--- a/modules/publishing_credential_policy/variables.tf
+++ b/modules/publishing_credential_policy/variables.tf
@@ -44,7 +44,7 @@ variable "ignore_body_changes" {
   description = <<DESCRIPTION
 Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, and this module manages its resource with a type that does not accept the argument. The variable exists for interface consistency; setting a non-empty value fails the plan with an explicit error rather than being silently ignored.
 - `web_sites_basic_publishing_credentials_policies` - Paths ignored on the publishing credential policy on a site.
 - `web_sites_slots_basic_publishing_credentials_policies` - Paths ignored on the publishing credential policy on a slot.
 DESCRIPTION

--- a/modules/publishing_credential_policy/variables.tf
+++ b/modules/publishing_credential_policy/variables.tf
@@ -35,14 +35,67 @@ variable "is_slot" {
   description = "Whether the parent resource is a deployment slot. Defaults to `false`."
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    web_sites_basic_publishing_credentials_policies       = optional(list(string), [])
+    web_sites_slots_basic_publishing_credentials_policies = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes are ignored, keyed by AzAPI resource type. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only. This module manages its resource with an AzAPI resource type that does not accept the argument, so the variable is declared for interface consistency and is not applied yet.
+- `web_sites_basic_publishing_credentials_policies` - Paths ignored on the publishing credential policy on a site.
+- `web_sites_slots_basic_publishing_credentials_policies` - Paths ignored on the publishing credential policy on a slot.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "resource_types" {
+  type = object({
+    web_sites_basic_publishing_credentials_policies       = optional(string, "Microsoft.Web/sites/basicPublishingCredentialsPolicies@2025-03-01")
+    web_sites_slots_basic_publishing_credentials_policies = optional(string, "Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies@2025-03-01")
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions used by this module.
+
+- `web_sites_basic_publishing_credentials_policies` - Resource type and API version for the publishing credential policy on a site.
+- `web_sites_slots_basic_publishing_credentials_policies` - Resource type and API version for the publishing credential policy on a slot.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "retry" {
   type = object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
   })
-  default = {
-    error_message_regex = ["Cannot modify this site because another operation is in progress"]
-  }
-  description = "Retry configuration for azapi resources."
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration for the AzAPI resources declared by this module. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+DESCRIPTION
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Per-operation timeouts applied to the AzAPI resources declared by this module. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+DESCRIPTION
 }

--- a/modules/slot/README.md
+++ b/modules/slot/README.md
@@ -289,7 +289,7 @@ Default: `null`
 
 Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type for resources this module declares, and by submodule name for resources its submodules declare. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, so the fields belonging to submodules that manage their resource through `azapi_update_resource` or `azapi_resource_action` are declared for interface consistency and are not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, so the fields belonging to submodules that manage their resource through `azapi_update_resource` or `azapi_resource_action` exist for interface consistency. Setting a non-empty value on one of those fails the plan with an explicit error rather than being silently ignored.
 
 - `authorization_locks` - Paths ignored on the management locks.
 - `authorization_role_assignments` - Paths ignored on the role assignments.

--- a/modules/slot/README.md
+++ b/modules/slot/README.md
@@ -19,7 +19,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_time"></a> [time](#requirement\_time) (>= 0.9.0, < 1.0.0)
 
@@ -285,6 +285,63 @@ Type: `bool`
 
 Default: `null`
 
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body-relative paths whose changes are ignored, keyed by AzAPI resource type for resources this module declares, and by submodule name for resources its submodules declare. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, so the fields belonging to submodules that manage their resource through `azapi_update_resource` or `azapi_resource_action` are declared for interface consistency and are not applied yet.
+
+- `authorization_locks` - Paths ignored on the management locks.
+- `authorization_role_assignments` - Paths ignored on the role assignments.
+- `network_private_endpoints` - Paths ignored on the private endpoints.
+- `network_private_endpoints_private_dns_zone_groups` - Paths ignored on the private DNS zone groups.
+- `web_sites_slots` - Paths ignored on the slot.
+- `config_appsettings` - Paths passed to the app settings submodule.
+- `config_azurestorageaccounts` - Paths passed to the storage account mounts submodule.
+- `config_connectionstrings` - Paths passed to the connection strings submodule.
+- `config_metadata` - Paths passed to the site metadata submodule.
+- `extensions_zipdeploy` - Paths passed to the zip deployment submodule.
+- `publishing_credential_policy` - Paths passed to the publishing credential policy submodules.
+
+Type:
+
+```hcl
+object({
+    authorization_locks                               = optional(list(string), [])
+    authorization_role_assignments                    = optional(list(string), [])
+    network_private_endpoints                         = optional(list(string), [])
+    network_private_endpoints_private_dns_zone_groups = optional(list(string), [])
+    web_sites_slots                                   = optional(list(string), [])
+
+    config_appsettings = optional(object({
+      web_sites_config       = optional(list(string), [])
+      web_sites_slots_config = optional(list(string), [])
+    }), {})
+    config_azurestorageaccounts = optional(object({
+      web_sites       = optional(list(string), [])
+      web_sites_slots = optional(list(string), [])
+    }), {})
+    config_connectionstrings = optional(object({
+      web_sites_config       = optional(list(string), [])
+      web_sites_slots_config = optional(list(string), [])
+    }), {})
+    config_metadata = optional(object({
+      web_sites_config       = optional(list(string), [])
+      web_sites_slots_config = optional(list(string), [])
+    }), {})
+    extensions_zipdeploy = optional(object({
+      web_sites       = optional(list(string), [])
+      web_sites_slots = optional(list(string), [])
+    }), {})
+    publishing_credential_policy = optional(object({
+      web_sites_basic_publishing_credentials_policies       = optional(list(string), [])
+      web_sites_slots_basic_publishing_credentials_policies = optional(list(string), [])
+    }), {})
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_ip_mode"></a> [ip\_mode](#input\_ip\_mode)
 
 Description: The IP mode. Possible values: `IPv4`, `IPv4AndIPv6`, `IPv6`.
@@ -439,29 +496,80 @@ object({
 
 Default: `null`
 
-### <a name="input_retry"></a> [retry](#input\_retry)
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
 
-Description: Retry configuration for azapi resources.
+Description: AzAPI resource types and API versions, keyed by resource type for resources this module declares, and by submodule name for resources its submodules declare. Each submodule owns the defaults for its own resources.
+
+- `authorization_locks` - Resource type and API version for the management locks.
+- `authorization_role_assignments` - Resource type and API version for the role assignments.
+- `network_private_endpoints` - Resource type and API version for the private endpoints.
+- `network_private_endpoints_private_dns_zone_groups` - Resource type and API version for the private DNS zone groups.
+- `web_sites_slots` - Resource type and API version for the slot.
+- `config_appsettings` - Resource-type overrides passed to the app settings submodule.
+- `config_azurestorageaccounts` - Resource-type overrides passed to the storage account mounts submodule.
+- `config_connectionstrings` - Resource-type overrides passed to the connection strings submodule.
+- `config_metadata` - Resource-type overrides passed to the site metadata submodule.
+- `extensions_zipdeploy` - Resource-type overrides passed to the zip deployment submodule.
+- `publishing_credential_policy` - Resource-type overrides passed to the publishing credential policy submodules.
 
 Type:
 
 ```hcl
 object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    authorization_locks                               = optional(string, "Microsoft.Authorization/locks@2020-05-01")
+    authorization_role_assignments                    = optional(string, "Microsoft.Authorization/roleAssignments@2022-04-01")
+    network_private_endpoints                         = optional(string, "Microsoft.Network/privateEndpoints@2024-05-01")
+    network_private_endpoints_private_dns_zone_groups = optional(string, "Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-05-01")
+    web_sites_slots                                   = optional(string, "Microsoft.Web/sites/slots@2025-03-01")
+
+    config_appsettings = optional(object({
+      web_sites_config       = optional(string)
+      web_sites_slots_config = optional(string)
+    }), {})
+    config_azurestorageaccounts = optional(object({
+      web_sites       = optional(string)
+      web_sites_slots = optional(string)
+    }), {})
+    config_connectionstrings = optional(object({
+      web_sites_config       = optional(string)
+      web_sites_slots_config = optional(string)
+    }), {})
+    config_metadata = optional(object({
+      web_sites_config       = optional(string)
+      web_sites_slots_config = optional(string)
+    }), {})
+    extensions_zipdeploy = optional(object({
+      web_sites       = optional(string)
+      web_sites_slots = optional(string)
+    }), {})
+    publishing_credential_policy = optional(object({
+      web_sites_basic_publishing_credentials_policies       = optional(string)
+      web_sites_slots_basic_publishing_credentials_policies = optional(string)
+    }), {})
   })
 ```
 
-Default:
+Default: `{}`
 
-```json
-{
-  "error_message_regex": [
-    "Cannot modify this site because another operation is in progress"
-  ]
-}
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration for the AzAPI resources declared by this module and its submodules. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
 ```
+
+Default: `{}`
 
 ### <a name="input_role_assignments"></a> [role\_assignments](#input\_role\_assignments)
 
@@ -763,6 +871,28 @@ Default: `{}`
 Description: Tags to apply to the slot.
 
 Type: `map(string)`
+
+Default: `null`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Per-operation timeouts applied to the AzAPI resources declared by this module and its submodules. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
 
 Default: `null`
 

--- a/modules/slot/main.interfaces.tf
+++ b/modules/slot/main.interfaces.tf
@@ -26,10 +26,22 @@ resource "azapi_resource" "lock" {
 
   name                   = each.value.name
   parent_id              = azapi_resource.this.id
-  type                   = each.value.type
+  type                   = var.resource_types.authorization_locks
   body                   = each.value.body
+  ignore_body_changes    = length(var.ignore_body_changes.authorization_locks) > 0 ? var.ignore_body_changes.authorization_locks : null
   response_export_values = []
   retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 resource "azapi_resource" "role_assignment" {
@@ -37,11 +49,23 @@ resource "azapi_resource" "role_assignment" {
 
   name                   = each.value.name
   parent_id              = azapi_resource.this.id
-  type                   = each.value.type
+  type                   = var.resource_types.authorization_role_assignments
   body                   = each.value.body
+  ignore_body_changes    = length(var.ignore_body_changes.authorization_role_assignments) > 0 ? var.ignore_body_changes.authorization_role_assignments : null
   ignore_null_property   = true
   response_export_values = []
   retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 resource "azapi_resource" "private_endpoint" {
@@ -50,11 +74,23 @@ resource "azapi_resource" "private_endpoint" {
   location               = coalesce(try(var.private_endpoints[each.key].location, null), var.location)
   name                   = each.value.name
   parent_id              = regex("^(/subscriptions/[^/]+/resourceGroups/[^/]+)", var.parent_id)[0]
-  type                   = each.value.type
+  type                   = var.resource_types.network_private_endpoints
   body                   = each.value.body
+  ignore_body_changes    = length(var.ignore_body_changes.network_private_endpoints) > 0 ? var.ignore_body_changes.network_private_endpoints : null
   response_export_values = []
   retry                  = var.retry
   tags                   = each.value.tags
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 resource "azapi_resource" "private_dns_zone_group" {
@@ -62,10 +98,22 @@ resource "azapi_resource" "private_dns_zone_group" {
 
   name                   = each.value.name
   parent_id              = azapi_resource.private_endpoint[each.key].id
-  type                   = each.value.type
+  type                   = var.resource_types.network_private_endpoints_private_dns_zone_groups
   body                   = each.value.body
+  ignore_body_changes    = length(var.ignore_body_changes.network_private_endpoints_private_dns_zone_groups) > 0 ? var.ignore_body_changes.network_private_endpoints_private_dns_zone_groups : null
   response_export_values = []
   retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 resource "azapi_resource" "lock_private_endpoint" {
@@ -73,10 +121,22 @@ resource "azapi_resource" "lock_private_endpoint" {
 
   name                   = each.value.name
   parent_id              = azapi_resource.private_endpoint[each.value.private_endpoint_key].id
-  type                   = each.value.type
+  type                   = var.resource_types.authorization_locks
   body                   = each.value.body
+  ignore_body_changes    = length(var.ignore_body_changes.authorization_locks) > 0 ? var.ignore_body_changes.authorization_locks : null
   response_export_values = []
   retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 resource "azapi_resource" "role_assignment_private_endpoint" {
@@ -84,7 +144,20 @@ resource "azapi_resource" "role_assignment_private_endpoint" {
 
   name                   = each.value.name
   parent_id              = azapi_resource.private_endpoint[each.value.private_endpoint_key].id
-  type                   = each.value.type
+  type                   = var.resource_types.authorization_role_assignments
   body                   = each.value.body
+  ignore_body_changes    = length(var.ignore_body_changes.authorization_role_assignments) > 0 ? var.ignore_body_changes.authorization_role_assignments : null
   response_export_values = []
+  retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }

--- a/modules/slot/main.tf
+++ b/modules/slot/main.tf
@@ -2,7 +2,7 @@ resource "azapi_resource" "this" {
   location  = var.location
   name      = var.name
   parent_id = var.parent_id
-  type      = "Microsoft.Web/sites/slots@2025-03-01"
+  type      = var.resource_types.web_sites_slots
   body = {
     kind = var.kind
     properties = {
@@ -142,6 +142,7 @@ resource "azapi_resource" "this" {
       } : null
     }
   }
+  ignore_body_changes  = length(var.ignore_body_changes.web_sites_slots) > 0 ? var.ignore_body_changes.web_sites_slots : null
   ignore_null_property = true
   response_export_values = [
     "identity.principalId",
@@ -157,26 +158,43 @@ resource "azapi_resource" "this" {
       identity_ids = identity.value.identity_ids
     }
   }
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 # Slot app settings
 module "config_appsettings" {
   source = "../config_appsettings"
 
-  app_settings = local.merged_app_settings
-  parent_id    = azapi_resource.this.id
-  is_slot      = true
-  retry        = var.retry
+  app_settings        = local.merged_app_settings
+  parent_id           = azapi_resource.this.id
+  ignore_body_changes = var.ignore_body_changes.config_appsettings
+  is_slot             = true
+  resource_types      = var.resource_types.config_appsettings
+  retry               = var.retry
+  timeouts            = var.timeouts
 }
 
 # Slot connection strings
 module "config_connectionstrings" {
   source = "../config_connectionstrings"
 
-  connection_strings = var.connection_strings
-  parent_id          = azapi_resource.this.id
-  is_slot            = true
-  retry              = var.retry
+  connection_strings  = var.connection_strings
+  parent_id           = azapi_resource.this.id
+  ignore_body_changes = var.ignore_body_changes.config_connectionstrings
+  is_slot             = true
+  resource_types      = var.resource_types.config_connectionstrings
+  retry               = var.retry
+  timeouts            = var.timeouts
 }
 
 # Slot storage account mounts
@@ -187,8 +205,11 @@ module "config_azurestorageaccounts" {
   storage_shares_to_mount = { for k, v in var.storage_shares_to_mount : k => merge(v, {
     access_key = var.storage_shares_access_keys[k]
   }) }
-  is_slot = true
-  retry   = var.retry
+  is_slot             = true
+  ignore_body_changes = var.ignore_body_changes.config_azurestorageaccounts
+  resource_types      = var.resource_types.config_azurestorageaccounts
+  retry               = var.retry
+  timeouts            = var.timeouts
 }
 
 # Slot FTP publishing credential policy
@@ -196,21 +217,27 @@ module "ftp_publishing_credential_policy" {
   source   = "../publishing_credential_policy"
   for_each = !var.ftp_publish_basic_authentication_enabled ? { "default" = {} } : {}
 
-  name      = "ftp"
-  parent_id = azapi_resource.this.id
-  allow     = false
-  is_slot   = true
-  retry     = var.retry
+  name                = "ftp"
+  parent_id           = azapi_resource.this.id
+  allow               = false
+  ignore_body_changes = var.ignore_body_changes.publishing_credential_policy
+  is_slot             = true
+  resource_types      = var.resource_types.publishing_credential_policy
+  retry               = var.retry
+  timeouts            = var.timeouts
 }
 
 # Slot metadata
 module "config_metadata" {
   source = "../config_metadata"
 
-  metadata  = { for m in coalesce(module.site_config_helpers.site_config_metadata, []) : m.name => m.value }
-  parent_id = azapi_resource.this.id
-  is_slot   = true
-  retry     = var.retry
+  metadata            = { for m in coalesce(module.site_config_helpers.site_config_metadata, []) : m.name => m.value }
+  parent_id           = azapi_resource.this.id
+  ignore_body_changes = var.ignore_body_changes.config_metadata
+  is_slot             = true
+  resource_types      = var.resource_types.config_metadata
+  retry               = var.retry
+  timeouts            = var.timeouts
 }
 
 # Slot SCM publishing credential policy
@@ -218,11 +245,14 @@ module "scm_publishing_credential_policy" {
   source   = "../publishing_credential_policy"
   for_each = !var.webdeploy_publish_basic_authentication_enabled ? { "default" = {} } : {}
 
-  name      = "scm"
-  parent_id = azapi_resource.this.id
-  allow     = false
-  is_slot   = true
-  retry     = var.retry
+  name                = "scm"
+  parent_id           = azapi_resource.this.id
+  allow               = false
+  ignore_body_changes = var.ignore_body_changes.publishing_credential_policy
+  is_slot             = true
+  resource_types      = var.resource_types.publishing_credential_policy
+  retry               = var.retry
+  timeouts            = var.timeouts
 }
 
 # Slot zip deploy
@@ -245,10 +275,13 @@ module "extensions_zipdeploy" {
   source   = "../extensions_zipdeploy"
   for_each = var.zip_deploy_file != null ? { "default" = {} } : {}
 
-  parent_id       = azapi_resource.this.id
-  zip_deploy_file = var.zip_deploy_file
-  is_slot         = true
-  retry           = var.retry
+  parent_id           = azapi_resource.this.id
+  zip_deploy_file     = var.zip_deploy_file
+  ignore_body_changes = var.ignore_body_changes.extensions_zipdeploy
+  is_slot             = true
+  resource_types      = var.resource_types.extensions_zipdeploy
+  retry               = var.retry
+  timeouts            = var.timeouts
 
   depends_on = [
     time_sleep.wait_before_zip_deploy,

--- a/modules/slot/terraform.tf
+++ b/modules/slot/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     time = {
       source  = "hashicorp/time"

--- a/modules/slot/variables.tf
+++ b/modules/slot/variables.tf
@@ -233,7 +233,7 @@ variable "ignore_body_changes" {
   description = <<DESCRIPTION
 Body-relative paths whose changes are ignored, keyed by AzAPI resource type for resources this module declares, and by submodule name for resources its submodules declare. Paths use dot notation, and a change takes effect only after an apply.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, so the fields belonging to submodules that manage their resource through `azapi_update_resource` or `azapi_resource_action` are declared for interface consistency and are not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, so the fields belonging to submodules that manage their resource through `azapi_update_resource` or `azapi_resource_action` exist for interface consistency. Setting a non-empty value on one of those fails the plan with an explicit error rather than being silently ignored.
 
 - `authorization_locks` - Paths ignored on the management locks.
 - `authorization_role_assignments` - Paths ignored on the role assignments.

--- a/modules/slot/variables.tf
+++ b/modules/slot/variables.tf
@@ -196,6 +196,60 @@ variable "hyper_v" {
   description = "Should the slot run in Hyper-V isolation?"
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    authorization_locks                               = optional(list(string), [])
+    authorization_role_assignments                    = optional(list(string), [])
+    network_private_endpoints                         = optional(list(string), [])
+    network_private_endpoints_private_dns_zone_groups = optional(list(string), [])
+    web_sites_slots                                   = optional(list(string), [])
+
+    config_appsettings = optional(object({
+      web_sites_config       = optional(list(string), [])
+      web_sites_slots_config = optional(list(string), [])
+    }), {})
+    config_azurestorageaccounts = optional(object({
+      web_sites       = optional(list(string), [])
+      web_sites_slots = optional(list(string), [])
+    }), {})
+    config_connectionstrings = optional(object({
+      web_sites_config       = optional(list(string), [])
+      web_sites_slots_config = optional(list(string), [])
+    }), {})
+    config_metadata = optional(object({
+      web_sites_config       = optional(list(string), [])
+      web_sites_slots_config = optional(list(string), [])
+    }), {})
+    extensions_zipdeploy = optional(object({
+      web_sites       = optional(list(string), [])
+      web_sites_slots = optional(list(string), [])
+    }), {})
+    publishing_credential_policy = optional(object({
+      web_sites_basic_publishing_credentials_policies       = optional(list(string), [])
+      web_sites_slots_basic_publishing_credentials_policies = optional(list(string), [])
+    }), {})
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes are ignored, keyed by AzAPI resource type for resources this module declares, and by submodule name for resources its submodules declare. Paths use dot notation, and a change takes effect only after an apply.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, so the fields belonging to submodules that manage their resource through `azapi_update_resource` or `azapi_resource_action` are declared for interface consistency and are not applied yet.
+
+- `authorization_locks` - Paths ignored on the management locks.
+- `authorization_role_assignments` - Paths ignored on the role assignments.
+- `network_private_endpoints` - Paths ignored on the private endpoints.
+- `network_private_endpoints_private_dns_zone_groups` - Paths ignored on the private DNS zone groups.
+- `web_sites_slots` - Paths ignored on the slot.
+- `config_appsettings` - Paths passed to the app settings submodule.
+- `config_azurestorageaccounts` - Paths passed to the storage account mounts submodule.
+- `config_connectionstrings` - Paths passed to the connection strings submodule.
+- `config_metadata` - Paths passed to the site metadata submodule.
+- `extensions_zipdeploy` - Paths passed to the zip deployment submodule.
+- `publishing_credential_policy` - Paths passed to the publishing credential policy submodules.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "ip_mode" {
   type        = string
   default     = null
@@ -292,6 +346,7 @@ variable "private_endpoints_manage_dns_zone_group" {
   type        = bool
   default     = true
   description = "Whether to manage DNS zone groups for private endpoints."
+  nullable    = false
 }
 
 variable "public_network_access_enabled" {
@@ -315,16 +370,72 @@ variable "resource_config" {
   description = "Resource config for Container App environment hosted apps."
 }
 
+variable "resource_types" {
+  type = object({
+    authorization_locks                               = optional(string, "Microsoft.Authorization/locks@2020-05-01")
+    authorization_role_assignments                    = optional(string, "Microsoft.Authorization/roleAssignments@2022-04-01")
+    network_private_endpoints                         = optional(string, "Microsoft.Network/privateEndpoints@2024-05-01")
+    network_private_endpoints_private_dns_zone_groups = optional(string, "Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-05-01")
+    web_sites_slots                                   = optional(string, "Microsoft.Web/sites/slots@2025-03-01")
+
+    config_appsettings = optional(object({
+      web_sites_config       = optional(string)
+      web_sites_slots_config = optional(string)
+    }), {})
+    config_azurestorageaccounts = optional(object({
+      web_sites       = optional(string)
+      web_sites_slots = optional(string)
+    }), {})
+    config_connectionstrings = optional(object({
+      web_sites_config       = optional(string)
+      web_sites_slots_config = optional(string)
+    }), {})
+    config_metadata = optional(object({
+      web_sites_config       = optional(string)
+      web_sites_slots_config = optional(string)
+    }), {})
+    extensions_zipdeploy = optional(object({
+      web_sites       = optional(string)
+      web_sites_slots = optional(string)
+    }), {})
+    publishing_credential_policy = optional(object({
+      web_sites_basic_publishing_credentials_policies       = optional(string)
+      web_sites_slots_basic_publishing_credentials_policies = optional(string)
+    }), {})
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions, keyed by resource type for resources this module declares, and by submodule name for resources its submodules declare. Each submodule owns the defaults for its own resources.
+
+- `authorization_locks` - Resource type and API version for the management locks.
+- `authorization_role_assignments` - Resource type and API version for the role assignments.
+- `network_private_endpoints` - Resource type and API version for the private endpoints.
+- `network_private_endpoints_private_dns_zone_groups` - Resource type and API version for the private DNS zone groups.
+- `web_sites_slots` - Resource type and API version for the slot.
+- `config_appsettings` - Resource-type overrides passed to the app settings submodule.
+- `config_azurestorageaccounts` - Resource-type overrides passed to the storage account mounts submodule.
+- `config_connectionstrings` - Resource-type overrides passed to the connection strings submodule.
+- `config_metadata` - Resource-type overrides passed to the site metadata submodule.
+- `extensions_zipdeploy` - Resource-type overrides passed to the zip deployment submodule.
+- `publishing_credential_policy` - Resource-type overrides passed to the publishing credential policy submodules.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "retry" {
   type = object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
   })
-  default = {
-    error_message_regex = ["Cannot modify this site because another operation is in progress"]
-  }
-  description = "Retry configuration for azapi resources."
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration for the AzAPI resources declared by this module and its submodules. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+DESCRIPTION
 }
 
 variable "role_assignments" {
@@ -598,6 +709,24 @@ variable "tags" {
   type        = map(string)
   default     = null
   description = "Tags to apply to the slot."
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Per-operation timeouts applied to the AzAPI resources declared by this module and its submodules. Defaults to `null`, which uses the provider defaults. Each value is a Go duration string such as `30m`.
+
+- `create` - (Optional) Timeout for create operations.
+- `delete` - (Optional) Timeout for delete operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+DESCRIPTION
 }
 
 variable "virtual_network_subnet_id" {

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.12"
     }
     modtm = {
       source  = "azure/modtm"

--- a/variables.tf
+++ b/variables.tf
@@ -1350,7 +1350,7 @@ variable "ignore_body_changes" {
   description = <<DESCRIPTION
 Body-relative paths whose changes are ignored, keyed by AzAPI resource type for resources this module declares, and by submodule name for resources its submodules declare. Paths use dot notation, and a change takes effect only after an apply. Configuration at an ignored path is not sent to Azure until the path is removed.
 
-The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, so the fields belonging to submodules that manage their resource through `azapi_update_resource` or `azapi_resource_action` are declared for interface consistency and are not applied yet.
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, so the fields belonging to submodules that manage their resource through `azapi_update_resource` or `azapi_resource_action` exist for interface consistency. Setting a non-empty value on one of those fails the plan with an explicit error rather than being silently ignored.
 
 - `authorization_locks` - Paths ignored on the management locks.
 - `authorization_role_assignments` - Paths ignored on the role assignments.

--- a/variables.tf
+++ b/variables.tf
@@ -1375,6 +1375,7 @@ The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, so th
 DESCRIPTION
   nullable    = false
 }
+
 variable "instance_memory_in_mb" {
   type        = number
   default     = 2048
@@ -1771,6 +1772,7 @@ Retry configuration for the AzAPI resources declared by this module and its subm
 - `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
 DESCRIPTION
 }
+
 variable "role_assignments" {
   type = map(object({
     role_definition_id_or_name             = string

--- a/variables.tf
+++ b/variables.tf
@@ -1258,6 +1258,123 @@ variable "hyper_v" {
   description = "(Optional) Should the App Service run in Hyper-V isolation?"
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    authorization_locks                               = optional(list(string), [])
+    authorization_role_assignments                    = optional(list(string), [])
+    insights_diagnostic_settings                      = optional(list(string), [])
+    network_private_endpoints                         = optional(list(string), [])
+    network_private_endpoints_private_dns_zone_groups = optional(list(string), [])
+    web_sites                                         = optional(list(string), [])
+
+    certificate = optional(object({
+      web_certificates = optional(list(string), [])
+    }), {})
+    config_appsettings = optional(object({
+      web_sites_config       = optional(list(string), [])
+      web_sites_slots_config = optional(list(string), [])
+    }), {})
+    config_authsettings = optional(object({
+      web_sites_config = optional(list(string), [])
+    }), {})
+    config_authsettingsv2 = optional(object({
+      web_sites_config = optional(list(string), [])
+    }), {})
+    config_azurestorageaccounts = optional(object({
+      web_sites       = optional(list(string), [])
+      web_sites_slots = optional(list(string), [])
+    }), {})
+    config_backup = optional(object({
+      web_sites_config = optional(list(string), [])
+    }), {})
+    config_connectionstrings = optional(object({
+      web_sites_config       = optional(list(string), [])
+      web_sites_slots_config = optional(list(string), [])
+    }), {})
+    config_logs = optional(object({
+      web_sites_config = optional(list(string), [])
+    }), {})
+    config_metadata = optional(object({
+      web_sites_config       = optional(list(string), [])
+      web_sites_slots_config = optional(list(string), [])
+    }), {})
+    config_slotconfignames = optional(object({
+      web_sites_config = optional(list(string), [])
+    }), {})
+    extensions_zipdeploy = optional(object({
+      web_sites       = optional(list(string), [])
+      web_sites_slots = optional(list(string), [])
+    }), {})
+    hostname_binding = optional(object({
+      web_sites_host_name_bindings       = optional(list(string), [])
+      web_sites_slots_host_name_bindings = optional(list(string), [])
+    }), {})
+    publishing_credential_policy = optional(object({
+      web_sites_basic_publishing_credentials_policies       = optional(list(string), [])
+      web_sites_slots_basic_publishing_credentials_policies = optional(list(string), [])
+    }), {})
+    slot = optional(object({
+      authorization_locks                               = optional(list(string), [])
+      authorization_role_assignments                    = optional(list(string), [])
+      network_private_endpoints                         = optional(list(string), [])
+      network_private_endpoints_private_dns_zone_groups = optional(list(string), [])
+      web_sites_slots                                   = optional(list(string), [])
+
+      config_appsettings = optional(object({
+        web_sites_config       = optional(list(string), [])
+        web_sites_slots_config = optional(list(string), [])
+      }), {})
+      config_azurestorageaccounts = optional(object({
+        web_sites       = optional(list(string), [])
+        web_sites_slots = optional(list(string), [])
+      }), {})
+      config_connectionstrings = optional(object({
+        web_sites_config       = optional(list(string), [])
+        web_sites_slots_config = optional(list(string), [])
+      }), {})
+      config_metadata = optional(object({
+        web_sites_config       = optional(list(string), [])
+        web_sites_slots_config = optional(list(string), [])
+      }), {})
+      extensions_zipdeploy = optional(object({
+        web_sites       = optional(list(string), [])
+        web_sites_slots = optional(list(string), [])
+      }), {})
+      publishing_credential_policy = optional(object({
+        web_sites_basic_publishing_credentials_policies       = optional(list(string), [])
+        web_sites_slots_basic_publishing_credentials_policies = optional(list(string), [])
+      }), {})
+    }), {})
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes are ignored, keyed by AzAPI resource type for resources this module declares, and by submodule name for resources its submodules declare. Paths use dot notation, and a change takes effect only after an apply. Configuration at an ignored path is not sent to Azure until the path is removed.
+
+The AzAPI provider exposes `ignore_body_changes` on `azapi_resource` only, so the fields belonging to submodules that manage their resource through `azapi_update_resource` or `azapi_resource_action` are declared for interface consistency and are not applied yet.
+
+- `authorization_locks` - Paths ignored on the management locks.
+- `authorization_role_assignments` - Paths ignored on the role assignments.
+- `insights_diagnostic_settings` - Paths ignored on the diagnostic settings.
+- `network_private_endpoints` - Paths ignored on the private endpoints.
+- `network_private_endpoints_private_dns_zone_groups` - Paths ignored on the private DNS zone groups.
+- `web_sites` - Paths ignored on the App Service site.
+- `certificate` - Paths passed to the certificate submodule.
+- `config_appsettings` - Paths passed to the app settings submodule.
+- `config_authsettings` - Paths passed to the v1 auth settings submodule.
+- `config_authsettingsv2` - Paths passed to the v2 auth settings submodule.
+- `config_azurestorageaccounts` - Paths passed to the storage account mounts submodule.
+- `config_backup` - Paths passed to the backup submodule.
+- `config_connectionstrings` - Paths passed to the connection strings submodule.
+- `config_logs` - Paths passed to the logs submodule.
+- `config_metadata` - Paths passed to the site metadata submodule.
+- `config_slotconfignames` - Paths passed to the sticky settings submodule.
+- `extensions_zipdeploy` - Paths passed to the zip deployment submodule.
+- `hostname_binding` - Paths passed to the hostname binding submodules.
+- `publishing_credential_policy` - Paths passed to the publishing credential policy submodules.
+- `slot` - Paths passed to the deployment slot submodule.
+DESCRIPTION
+  nullable    = false
+}
 variable "instance_memory_in_mb" {
   type        = number
   default     = 2048
@@ -1523,24 +1640,137 @@ variable "resource_config" {
 DESCRIPTION
 }
 
-variable "retry" {
+variable "resource_types" {
   type = object({
-    error_message_regex = list(string)
-    interval_seconds    = optional(number, 10)
-    max_retries         = optional(number, 3)
-  })
-  default = {
-    error_message_regex = ["Cannot modify this site because another operation is in progress"]
-  }
-  description = <<-EOT
-Retry configuration for all azapi resources. Defaults to retrying on 409 Conflict errors caused by concurrent operations.
+    authorization_locks                               = optional(string, "Microsoft.Authorization/locks@2020-05-01")
+    authorization_role_assignments                    = optional(string, "Microsoft.Authorization/roleAssignments@2022-04-01")
+    insights_diagnostic_settings                      = optional(string, "Microsoft.Insights/diagnosticSettings@2021-05-01-preview")
+    network_private_endpoints                         = optional(string, "Microsoft.Network/privateEndpoints@2024-05-01")
+    network_private_endpoints_private_dns_zone_groups = optional(string, "Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-05-01")
+    web_sites                                         = optional(string, "Microsoft.Web/sites@2025-03-01")
 
-- `error_message_regex` - (Required) A list of regular expressions to match against error messages. If any match, the operation will be retried.
-- `interval_seconds` - (Optional) The initial interval in seconds between retries. Defaults to `10`.
-- `max_retries` - (Optional) The maximum number of retries. Defaults to `3`.
-EOT
+    certificate = optional(object({
+      web_certificates = optional(string)
+    }), {})
+    config_appsettings = optional(object({
+      web_sites_config       = optional(string)
+      web_sites_slots_config = optional(string)
+    }), {})
+    config_authsettings = optional(object({
+      web_sites_config = optional(string)
+    }), {})
+    config_authsettingsv2 = optional(object({
+      web_sites_config = optional(string)
+    }), {})
+    config_azurestorageaccounts = optional(object({
+      web_sites       = optional(string)
+      web_sites_slots = optional(string)
+    }), {})
+    config_backup = optional(object({
+      web_sites_config = optional(string)
+    }), {})
+    config_connectionstrings = optional(object({
+      web_sites_config       = optional(string)
+      web_sites_slots_config = optional(string)
+    }), {})
+    config_logs = optional(object({
+      web_sites_config = optional(string)
+    }), {})
+    config_metadata = optional(object({
+      web_sites_config       = optional(string)
+      web_sites_slots_config = optional(string)
+    }), {})
+    config_slotconfignames = optional(object({
+      web_sites_config = optional(string)
+    }), {})
+    extensions_zipdeploy = optional(object({
+      web_sites       = optional(string)
+      web_sites_slots = optional(string)
+    }), {})
+    hostname_binding = optional(object({
+      web_sites_host_name_bindings       = optional(string)
+      web_sites_slots_host_name_bindings = optional(string)
+    }), {})
+    publishing_credential_policy = optional(object({
+      web_sites_basic_publishing_credentials_policies       = optional(string)
+      web_sites_slots_basic_publishing_credentials_policies = optional(string)
+    }), {})
+    slot = optional(object({
+      authorization_locks                               = optional(string)
+      authorization_role_assignments                    = optional(string)
+      network_private_endpoints                         = optional(string)
+      network_private_endpoints_private_dns_zone_groups = optional(string)
+      web_sites_slots                                   = optional(string)
+
+      config_appsettings = optional(object({
+        web_sites_config       = optional(string)
+        web_sites_slots_config = optional(string)
+      }), {})
+      config_azurestorageaccounts = optional(object({
+        web_sites       = optional(string)
+        web_sites_slots = optional(string)
+      }), {})
+      config_connectionstrings = optional(object({
+        web_sites_config       = optional(string)
+        web_sites_slots_config = optional(string)
+      }), {})
+      config_metadata = optional(object({
+        web_sites_config       = optional(string)
+        web_sites_slots_config = optional(string)
+      }), {})
+      extensions_zipdeploy = optional(object({
+        web_sites       = optional(string)
+        web_sites_slots = optional(string)
+      }), {})
+      publishing_credential_policy = optional(object({
+        web_sites_basic_publishing_credentials_policies       = optional(string)
+        web_sites_slots_basic_publishing_credentials_policies = optional(string)
+      }), {})
+    }), {})
+  })
+  default     = {}
+  description = <<DESCRIPTION
+AzAPI resource types and API versions, keyed by resource type for resources this module declares, and by submodule name for resources its submodules declare. Each submodule owns the API-version defaults for its own resources, so nested fields have no defaults here.
+
+- `authorization_locks` - Resource type and API version for the management locks.
+- `authorization_role_assignments` - Resource type and API version for the role assignments.
+- `insights_diagnostic_settings` - Resource type and API version for the diagnostic settings.
+- `network_private_endpoints` - Resource type and API version for the private endpoints.
+- `network_private_endpoints_private_dns_zone_groups` - Resource type and API version for the private DNS zone groups.
+- `web_sites` - Resource type and API version for the App Service site.
+- `certificate` - Resource-type overrides passed to the certificate submodule.
+- `config_appsettings` - Resource-type overrides passed to the app settings submodule.
+- `config_authsettings` - Resource-type overrides passed to the v1 auth settings submodule.
+- `config_authsettingsv2` - Resource-type overrides passed to the v2 auth settings submodule.
+- `config_azurestorageaccounts` - Resource-type overrides passed to the storage account mounts submodule.
+- `config_backup` - Resource-type overrides passed to the backup submodule.
+- `config_connectionstrings` - Resource-type overrides passed to the connection strings submodule.
+- `config_logs` - Resource-type overrides passed to the logs submodule.
+- `config_metadata` - Resource-type overrides passed to the site metadata submodule.
+- `config_slotconfignames` - Resource-type overrides passed to the sticky settings submodule.
+- `extensions_zipdeploy` - Resource-type overrides passed to the zip deployment submodule.
+- `hostname_binding` - Resource-type overrides passed to the hostname binding submodules.
+- `publishing_credential_policy` - Resource-type overrides passed to the publishing credential policy submodules.
+- `slot` - Resource-type overrides passed to the deployment slot submodule.
+DESCRIPTION
+  nullable    = false
 }
 
+variable "retry" {
+  type = object({
+    error_message_regex  = optional(list(string), ["Cannot modify this site because another operation is in progress"])
+    interval_seconds     = optional(number, 10)
+    max_interval_seconds = optional(number)
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Retry configuration for the AzAPI resources declared by this module and its submodules. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
+
+- `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
+- `interval_seconds` - (Optional) The initial interval in seconds between retries.
+- `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
+DESCRIPTION
+}
 variable "role_assignments" {
   type = map(object({
     role_definition_id_or_name             = string


### PR DESCRIPTION
Fixes #351

## What was broken

`avm pr-check`'s `lint` step fails on every pull request, so nothing can merge on a fully green run. The failure is pre-existing on `main`: the root module and all 14 submodules that directly declare an AzAPI resource are missing the variables TFFR6, TFFR7 and TFFR8 require. It only surfaced now because the last substantive merge predates the job, and every merge since has been a `[skip ci]` managed-file sync.

The issue named five submodules from an abridged log. The full CI log flags **every** scope that declares an AzAPI resource — the root plus 14 submodules — so this pull request covers all of them.

## What changed

Each applicable scope now declares `resource_types`, `ignore_body_changes` and `timeouts`, and `retry` moves to the TFFR7 object shape. Nothing is declared and left dangling: `type` reads from `var.resource_types`, `timeouts` is emitted as a `dynamic` block, `ignore_body_changes` collapses `[]` to `null`, and every parent cascades all four values into the submodules it instantiates.

Modules touched: root, `certificate`, `config_appsettings`, `config_authsettings`, `config_authsettingsv2`, `config_azurestorageaccounts`, `config_backup`, `config_connectionstrings`, `config_logs`, `config_metadata`, `config_slotconfignames`, `extensions_zipdeploy`, `hostname_binding`, `publishing_credential_policy`, `slot`. `site_config_helpers` is the only submodule left alone — it declares no resources at all, so TFFR6-8 don't apply to it.

`modules/slot/variables.tf` also gets `nullable = false` on `private_endpoints_manage_dns_zone_group`, which the private-endpoint interface schema requires.

### Variable shapes

Straight from [TFFR6](https://azure.github.io/Azure-Verified-Modules/spec/TFFR6/), [TFFR7](https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/) and [TFFR8](https://azure.github.io/Azure-Verified-Modules/spec/TFFR8/):

- `resource_types` — a single `object`, `default = {}`, `nullable = false`, one `optional(string, "<type>@<api-version>")` per owned resource, plus a nested `optional(object({...}), {})` per submodule that repeats no child defaults.
- `ignore_body_changes` — same shape and keys, but `optional(list(string), [])` per owned resource.
- `retry` — `error_message_regex`, `interval_seconds` and `max_interval_seconds`, all optional.
- `timeouts` — `create`, `read`, `update`, `delete`, all optional, defaulting to `null`.

Every API-version default is the string that was hard-coded at that call site before, so no resource changes API version. The interface defaults (`Microsoft.Authorization/locks@2020-05-01`, `Microsoft.Authorization/roleAssignments@2022-04-01`, `Microsoft.Insights/diagnosticSettings@2021-05-01-preview`, `Microsoft.Network/privateEndpoints@2024-05-01` and its `privateDnsZoneGroups`) are the exact strings `Azure/avm-utl-interfaces/azure` 0.5.1 emits today.

### One deliberate deviation

TFFR6 keys nested submodule slots by the child's primary ARM type. That doesn't work here: eight submodules share `Microsoft.Web/sites/config`, and two more share `Microsoft.Web/sites` with the root's own resource, so the keys would collide. Nested slots are keyed by submodule name instead (`config_appsettings`, `hostname_binding`, `slot`, and so on), which still mirrors the module tree as the spec intends. Owned-resource keys inside each module follow the ARM rule exactly, including the `_slots_` variants these submodules pick between via `is_slot`.

## Consumer-visible changes

For the release notes:

1. **`retry.max_retries` is gone.** The AzAPI provider has no such attribute. Terraform was silently dropping it during object-to-nested-attribute conversion, so it has never done anything, but anyone passing it now gets a type error and should drop it. `error_message_regex` and `interval_seconds` keep their current defaults, so retry behaviour is unchanged.
2. **The `azapi` constraint moves from `~> 2.9` to `~> 2.12`.** TFFR8 requires it: `ignore_body_changes` is a write-only argument that landed in 2.12.0.
3. `slot`'s `role_assignment_private_endpoint` resource now gets `retry`, which it was missing. TFFR7 requires `retry` on every AzAPI resource.

New `timeouts` variables all default to `null`, so provider defaults still apply and no existing deployment changes.

## A provider limitation worth knowing about

`ignore_body_changes` exists on `azapi_resource` only — not on `azapi_update_resource` or `azapi_resource_action`, as of azapi 2.12.0, the current release. The lint rule requires the variable in every applicable scope regardless, so submodules built on those two types declare it and wire nothing. Their variable descriptions say so plainly rather than accepting input that silently does nothing. It is applied for real on the root site, `certificate`, `hostname_binding`, `slot`, and all the interface resources.

## Testing

Docker isn't available on this machine, so I could not run `./avm pre-commit` or `./avm pr-check` locally at all — CI is the only place this lint actually runs, and I expect to iterate against it.

What I did run:

- `terraform fmt -recursive -check` — clean.
- `terraform validate` on the root and all 15 submodules — all pass.
- `terraform validate` on the `interfaces`, `submodules`, `deployment_slot_with_interfaces`, `logic_app` and `default` examples — all pass.
- READMEs regenerated per directory with each directory's own `.terraform-docs.yml`.

There are no unit tests to run: `tests/` contains only a `README.md`, and a bare `terraform test` reports "Success! 0 passed, 0 failed" without running anything.

Nothing was deployed.

## Expected conflicts

This lands first, and the queued fixes rebase onto it. Overlapping files:

- #343 — `modules/certificate/main.tf`, `modules/hostname_binding/main.tf`
- #344 — `variables.tf`, `README.md`
- #345 — `variables.tf`, `modules/slot/main.tf`, `README.md`
- #346 — `main.interfaces.tf`, `modules/slot/main.interfaces.tf`, `modules/slot/variables.tf`, `variables.tf`, `README.md`
- #347 — no overlap
- #348 — `modules/slot/main.tf`
- #349 — `variables.tf`, `README.md`
- #350 — `main.tf`, `main.slots.tf`, `modules/slot/main.tf`, `modules/slot/variables.tf`, `variables.tf`, both `README.md`s

#346 is the tightest, since it rewrites the same interface resources. Every generated `README.md` conflict should be resolved by regenerating, never by hand.

_Drafted by Claude Opus 5._


---

## Update: the declared-but-unwired variables now reject input

The first version of this PR declared `ignore_body_changes` on the eleven submodules built from `azapi_update_resource` and `azapi_resource_action` and wired it nowhere, because the AzAPI provider only implements the attribute on `azapi_resource`. `tflint` was right to flag that: eleven `terraform_unused_declarations` warnings, which fail the `lint` step.

That looks like a catch-22 between TFFR8 and `terraform_unused_declarations`, but it isn't. Removing the declarations doesn't work — TFFR8's applicability list explicitly covers `azapi_update_resource` and `azapi_resource_action`, and the original CI log flagged exactly those files (`modules/config_slotconfignames/main.tf:1`, whose line 1 is `resource "azapi_update_resource"`, and `modules/config_azurestorageaccounts/main.tf:1`, whose line 1 is `resource "azapi_resource_action"`). The rule fires on all four supported types, so the declarations are genuinely required.

Rather than suppress the warning, each of those submodules now carries a `lifecycle` precondition asserting the value is empty:

```hcl
lifecycle {
  precondition {
    condition     = length(var.ignore_body_changes.web_sites_config) == 0
    error_message = "`ignore_body_changes` is not supported here. This module manages its resource with `azapi_update_resource`, which the AzAPI provider does not give an `ignore_body_changes` argument, so any value set would be silently ignored."
  }
}
```

This satisfies TFFR8, satisfies `terraform_unused_declarations` honestly rather than with eleven `tflint-ignore` annotations, and improves the contract: a consumer who sets one of these fields gets an explicit plan error naming the provider limitation instead of silently getting nothing. The variable descriptions say so.

The five scopes that *can* honour the argument — the root site, `certificate`, `hostname_binding`, `slot`, and all the interface resources — apply it for real.

## Examples moved to the same azapi floor

The module went to `~> 2.12` but all 22 examples were left on `~> 2.9`. Terraform resolves the intersection and picks >= 2.12 either way, so nothing was broken, but examples ship as documentation and would have stated a floor the module they call cannot honour. They're now all `~> 2.12`.

## Pre-existing warnings, not from this change

`avm pr-check` emits two deprecation warnings that predate this PR and are **not** new breakage:

```
[deprecated_lock_interface] lock uses deprecated interface variant 1; migrate to variant 2 by adding notes = optional(string, null)
[deprecated_role_assignments_interface] role_assignments uses deprecated interface variant 1; migrate to variant 2 by adding name = optional(string, null)
```

Both stem from the `Azure/avm-utl-interfaces` pin sitting at `0.5.1` (identical in `main.interfaces.tf` and `modules/slot/main.interfaces.tf`). That's tracked by #357 and deliberately out of scope here — bumping the utility module can change the emitted request bodies, which does not belong in a lint-compliance change.

## Verification

`avm pre-commit` and `avm pr-check` both run locally without Docker — CI installs `Avm.Authoring` from the PowerShell Gallery onto a plain runner, and the same path works on a workstation. Full local `avm pr-check` on this branch:

```
[pass] sync              [pass] check policy
[pass] format            [pass] check convention
[pass] transform         [pass] validate
[pass] lint              [pass] docs
avm pr-check: pass
```

_Drafted by Claude Opus 5._
