### PR TITLE
fix: remove unsupported example retry limits

### DIFF
--- a/examples/deployment_slot_with_interfaces/README.md
+++ b/examples/deployment_slot_with_interfaces/README.md
@@ -102,7 +102,6 @@ resource "azapi_resource" "private_dns_zone" {
   retry = {
     error_message_regex = ["CannotDeleteResource"]
     interval_seconds    = 10
-    max_retries         = 3
   }
 }
 

--- a/examples/deployment_slot_with_interfaces/README.md
+++ b/examples/deployment_slot_with_interfaces/README.md
@@ -99,6 +99,7 @@ resource "azapi_resource" "private_dns_zone" {
   parent_id = azapi_resource.resource_group.id
   type      = "Microsoft.Network/privateDnsZones@2024-06-01"
   body      = {}
+  # Custom retries stop when the resource's delete timeout expires (30 minutes by default).
   retry = {
     error_message_regex = ["CannotDeleteResource"]
     interval_seconds    = 10

--- a/examples/deployment_slot_with_interfaces/main.tf
+++ b/examples/deployment_slot_with_interfaces/main.tf
@@ -88,6 +88,7 @@ resource "azapi_resource" "private_dns_zone" {
   parent_id = azapi_resource.resource_group.id
   type      = "Microsoft.Network/privateDnsZones@2024-06-01"
   body      = {}
+  # Custom retries stop when the resource's delete timeout expires (30 minutes by default).
   retry = {
     error_message_regex = ["CannotDeleteResource"]
     interval_seconds    = 10

--- a/examples/deployment_slot_with_interfaces/main.tf
+++ b/examples/deployment_slot_with_interfaces/main.tf
@@ -91,7 +91,6 @@ resource "azapi_resource" "private_dns_zone" {
   retry = {
     error_message_regex = ["CannotDeleteResource"]
     interval_seconds    = 10
-    max_retries         = 3
   }
 }
 

--- a/examples/interfaces/README.md
+++ b/examples/interfaces/README.md
@@ -139,6 +139,7 @@ resource "azapi_resource" "private_dns_zone" {
   parent_id = azapi_resource.resource_group.id
   type      = "Microsoft.Network/privateDnsZones@2024-06-01"
   body      = {}
+  # Custom retries stop when the resource's delete timeout expires (30 minutes by default).
   retry = {
     error_message_regex = ["CannotDeleteResource"]
     interval_seconds    = 10

--- a/examples/interfaces/README.md
+++ b/examples/interfaces/README.md
@@ -142,7 +142,6 @@ resource "azapi_resource" "private_dns_zone" {
   retry = {
     error_message_regex = ["CannotDeleteResource"]
     interval_seconds    = 10
-    max_retries         = 3
   }
 }
 

--- a/examples/interfaces/main.tf
+++ b/examples/interfaces/main.tf
@@ -126,7 +126,6 @@ resource "azapi_resource" "private_dns_zone" {
   retry = {
     error_message_regex = ["CannotDeleteResource"]
     interval_seconds    = 10
-    max_retries         = 3
   }
 }
 

--- a/examples/interfaces/main.tf
+++ b/examples/interfaces/main.tf
@@ -123,6 +123,7 @@ resource "azapi_resource" "private_dns_zone" {
   parent_id = azapi_resource.resource_group.id
   type      = "Microsoft.Network/privateDnsZones@2024-06-01"
   body      = {}
+  # Custom retries stop when the resource's delete timeout expires (30 minutes by default).
   retry = {
     error_message_regex = ["CannotDeleteResource"]
     interval_seconds    = 10

--- a/examples/logic_app/README.md
+++ b/examples/logic_app/README.md
@@ -132,7 +132,6 @@ resource "azapi_resource" "private_dns_zone" {
   retry = {
     error_message_regex = ["CannotDeleteResource"]
     interval_seconds    = 10
-    max_retries         = 3
   }
 }
 

--- a/examples/logic_app/README.md
+++ b/examples/logic_app/README.md
@@ -129,6 +129,7 @@ resource "azapi_resource" "private_dns_zone" {
   parent_id = azapi_resource.resource_group.id
   type      = "Microsoft.Network/privateDnsZones@2024-06-01"
   body      = {}
+  # Custom retries stop when the resource's delete timeout expires (30 minutes by default).
   retry = {
     error_message_regex = ["CannotDeleteResource"]
     interval_seconds    = 10

--- a/examples/logic_app/main.tf
+++ b/examples/logic_app/main.tf
@@ -118,6 +118,7 @@ resource "azapi_resource" "private_dns_zone" {
   parent_id = azapi_resource.resource_group.id
   type      = "Microsoft.Network/privateDnsZones@2024-06-01"
   body      = {}
+  # Custom retries stop when the resource's delete timeout expires (30 minutes by default).
   retry = {
     error_message_regex = ["CannotDeleteResource"]
     interval_seconds    = 10

--- a/examples/logic_app/main.tf
+++ b/examples/logic_app/main.tf
@@ -121,7 +121,6 @@ resource "azapi_resource" "private_dns_zone" {
   retry = {
     error_message_regex = ["CannotDeleteResource"]
     interval_seconds    = 10
-    max_retries         = 3
   }
 }
 


### PR DESCRIPTION
## Summary

- Remove the unsupported `max_retries` attribute from three AzAPI retry blocks.
- Preserve behavior because AzAPI never read `max_retries`; retries remain bounded by the resource's 30-minute default delete timeout.
- Document that timeout behavior without pinning the provider default in configuration.
- Regenerate the affected example READMEs from `examples/.terraform-docs.yml`.

## Validation

- `terraform fmt -check` on the three changed examples
- `avm pre-commit`
- `avm pr-check`

Fixes #359

_Drafted by GPT-5.6 Sol._