### PR TITLE
Remove sensitive attribute from output variables where it is not needed

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -29,7 +29,6 @@ output "deployment_slots" {
 
 output "identity_principal_id" {
   description = "The system-assigned managed identity principal ID of the resource."
-  sensitive   = true
   value       = try(azapi_resource.this.output.identity.principalId, null)
 }
 
@@ -68,7 +67,6 @@ output "resource" {
 
 output "resource_id" {
   description = "The resource ID of the App Service."
-  sensitive   = true
   value       = azapi_resource.this.id
 }
 
@@ -89,13 +87,11 @@ output "resource_uri" {
 
 output "system_assigned_mi_principal_id" {
   description = "The system-assigned managed identity principal ID."
-  sensitive   = true
   value       = try(azapi_resource.this.output.identity.principalId, null)
 }
 
 output "system_assigned_mi_principal_id_slots" {
   description = "Map of system-assigned managed identity principal IDs for deployment slots."
-  sensitive   = true
   value = {
     for slot_key, slot in module.slot :
     slot_key => slot.identity_principal_id


### PR DESCRIPTION
## Description

resource_id, system_assigned_mi_principal_id, identity_principal_id, and system_assigned_mi_principal_id_slots are all unnecessarily marked as sensitive. These are output which are very likely to be used and do not contain any sensitive data.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
