### PR TITLE
fix!: remove unused whole-resource outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2679,13 +2679,9 @@ an `asuid.<custom-hostname>` TXT record in your DNS zone before binding a custom
 domain via `var.custom_domains`. See the `custom_domains` variable documentation  
 for details on the DNS prerequisites that Azure enforces.
 
-### <a name="output_deployment_slot_locks"></a> [deployment\_slot\_locks](#output\_deployment\_slot\_locks)
-
-Description: The locks of the deployment slots.
-
 ### <a name="output_deployment_slots"></a> [deployment\_slots](#output\_deployment\_slots)
 
-Description: The deployment slots.
+Description: A map of deployment slots with their names and resource IDs. The map key is the supplied input to var.deployment\_slots.
 
 ### <a name="output_identity_principal_id"></a> [identity\_principal\_id](#output\_identity\_principal\_id)
 
@@ -2707,10 +2703,6 @@ Description: The name of the resource.
 
 Description: The operating system type of the resource.
 
-### <a name="output_private_endpoints"></a> [private\_endpoints](#output\_private\_endpoints)
-
-Description: A map of private endpoints. The map key is the supplied input to var.private\_endpoints.
-
 ### <a name="output_resource"></a> [resource](#output\_resource)
 
 Description: This is the full output for the resource.
@@ -2718,14 +2710,6 @@ Description: This is the full output for the resource.
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The resource ID of the App Service.
-
-### <a name="output_resource_lock"></a> [resource\_lock](#output\_resource\_lock)
-
-Description: The locks of the resources.
-
-### <a name="output_resource_private_endpoints"></a> [resource\_private\_endpoints](#output\_resource\_private\_endpoints)
-
-Description: A map of private endpoints. The map key is the supplied input to var.private\_endpoints. The map value is the entire azapi\_resource.
 
 ### <a name="output_resource_uri"></a> [resource\_uri](#output\_resource\_uri)
 

--- a/README.md
+++ b/README.md
@@ -2703,6 +2703,10 @@ Description: The name of the resource.
 
 Description: The operating system type of the resource.
 
+### <a name="output_private_endpoints"></a> [private\_endpoints](#output\_private\_endpoints)
+
+Description: A map of private endpoints. The map key is the supplied input to var.private\_endpoints.
+
 ### <a name="output_resource"></a> [resource](#output\_resource)
 
 Description: This is the full output for the resource.

--- a/examples/auto_heal_enabled/README.md
+++ b/examples/auto_heal_enabled/README.md
@@ -180,7 +180,7 @@ Description: ID of active slot
 
 ### <a name="output_deployment_slots"></a> [deployment\_slots](#output\_deployment\_slots)
 
-Description: Full output of deployment slots created
+Description: Names and resource IDs of the deployment slots.
 
 ### <a name="output_location"></a> [location](#output\_location)
 

--- a/examples/auto_heal_enabled/outputs.tf
+++ b/examples/auto_heal_enabled/outputs.tf
@@ -4,8 +4,7 @@ output "active_slot" {
 }
 
 output "deployment_slots" {
-  description = "Full output of deployment slots created"
-  sensitive   = true
+  description = "Names and resource IDs of the deployment slots."
   value       = module.avm_res_web_site.deployment_slots
 }
 

--- a/modules/certificate/README.md
+++ b/modules/certificate/README.md
@@ -223,10 +223,6 @@ Description: The status of the Key Vault secret poll. Useful for diagnosing miss
 
 Description: The name of the certificate.
 
-### <a name="output_resource"></a> [resource](#output\_resource)
-
-Description: The full resource object.
-
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The resource ID of the certificate.

--- a/modules/certificate/outputs.tf
+++ b/modules/certificate/outputs.tf
@@ -18,14 +18,6 @@ output "name" {
   value       = azapi_resource.this.name
 }
 
-# This output shipped in v0.22.0, so keep it until a breaking release can remove it.
-output "resource" {
-  description = "The full resource object."
-  sensitive   = true
-  # tflint-ignore: no_entire_resource_output_tffr2
-  value = azapi_resource.this
-}
-
 output "resource_id" {
   description = "The resource ID of the certificate."
   value       = azapi_resource.this.id

--- a/modules/config_appsettings/README.md
+++ b/modules/config_appsettings/README.md
@@ -137,10 +137,6 @@ The following outputs are exported:
 
 Description: The name of the config resource.
 
-### <a name="output_resource"></a> [resource](#output\_resource)
-
-Description: The full resource object.
-
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The resource ID of the config resource.

--- a/modules/config_appsettings/outputs.tf
+++ b/modules/config_appsettings/outputs.tf
@@ -3,12 +3,6 @@ output "name" {
   value       = azapi_update_resource.this.name
 }
 
-output "resource" {
-  description = "The full resource object."
-  # tflint-ignore: no_entire_resource_output_tffr2
-  value = azapi_update_resource.this
-}
-
 output "resource_id" {
   description = "The resource ID of the config resource."
   value       = azapi_update_resource.this.id

--- a/modules/config_authsettings/README.md
+++ b/modules/config_authsettings/README.md
@@ -323,10 +323,6 @@ The following outputs are exported:
 
 Description: The name of the config resource.
 
-### <a name="output_resource"></a> [resource](#output\_resource)
-
-Description: The full resource object.
-
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The resource ID of the config resource.

--- a/modules/config_authsettings/outputs.tf
+++ b/modules/config_authsettings/outputs.tf
@@ -3,12 +3,6 @@ output "name" {
   value       = azapi_update_resource.this.name
 }
 
-output "resource" {
-  description = "The full resource object."
-  # tflint-ignore: no_entire_resource_output_tffr2
-  value = azapi_update_resource.this
-}
-
 output "resource_id" {
   description = "The resource ID of the config resource."
   value       = azapi_update_resource.this.id

--- a/modules/config_authsettingsv2/README.md
+++ b/modules/config_authsettingsv2/README.md
@@ -492,10 +492,6 @@ The following outputs are exported:
 
 Description: The name of the config resource.
 
-### <a name="output_resource"></a> [resource](#output\_resource)
-
-Description: The full resource object.
-
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The resource ID of the config resource.

--- a/modules/config_authsettingsv2/outputs.tf
+++ b/modules/config_authsettingsv2/outputs.tf
@@ -3,12 +3,6 @@ output "name" {
   value       = azapi_update_resource.this.name
 }
 
-output "resource" {
-  description = "The full resource object."
-  # tflint-ignore: no_entire_resource_output_tffr2
-  value = azapi_update_resource.this
-}
-
 output "resource_id" {
   description = "The resource ID of the config resource."
   value       = azapi_update_resource.this.id

--- a/modules/config_azurestorageaccounts/README.md
+++ b/modules/config_azurestorageaccounts/README.md
@@ -155,10 +155,6 @@ The following outputs are exported:
 
 Description: The name of the config resource.
 
-### <a name="output_resource"></a> [resource](#output\_resource)
-
-Description: The full resource object.
-
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The resource ID of the config resource.

--- a/modules/config_azurestorageaccounts/outputs.tf
+++ b/modules/config_azurestorageaccounts/outputs.tf
@@ -3,12 +3,6 @@ output "name" {
   value       = "azurestorageaccounts"
 }
 
-output "resource" {
-  description = "The full resource object."
-  # tflint-ignore: no_entire_resource_output_tffr2
-  value = azapi_resource_action.this
-}
-
 output "resource_id" {
   description = "The resource ID of the config resource."
   value       = "${var.parent_id}/config/azurestorageaccounts"

--- a/modules/config_backup/README.md
+++ b/modules/config_backup/README.md
@@ -167,10 +167,6 @@ The following outputs are exported:
 
 Description: The name of the config resource.
 
-### <a name="output_resource"></a> [resource](#output\_resource)
-
-Description: The full resource object.
-
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The resource ID of the config resource.

--- a/modules/config_backup/outputs.tf
+++ b/modules/config_backup/outputs.tf
@@ -3,12 +3,6 @@ output "name" {
   value       = azapi_update_resource.this.name
 }
 
-output "resource" {
-  description = "The full resource object."
-  # tflint-ignore: no_entire_resource_output_tffr2
-  value = azapi_update_resource.this
-}
-
 output "resource_id" {
   description = "The resource ID of the config resource."
   value       = azapi_update_resource.this.id

--- a/modules/config_connectionstrings/README.md
+++ b/modules/config_connectionstrings/README.md
@@ -149,10 +149,6 @@ The following outputs are exported:
 
 Description: The name of the config resource.
 
-### <a name="output_resource"></a> [resource](#output\_resource)
-
-Description: The full resource object.
-
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The resource ID of the config resource.

--- a/modules/config_connectionstrings/outputs.tf
+++ b/modules/config_connectionstrings/outputs.tf
@@ -3,12 +3,6 @@ output "name" {
   value       = azapi_update_resource.this.name
 }
 
-output "resource" {
-  description = "The full resource object."
-  # tflint-ignore: no_entire_resource_output_tffr2
-  value = azapi_update_resource.this
-}
-
 output "resource_id" {
   description = "The resource ID of the config resource."
   value       = azapi_update_resource.this.id

--- a/modules/config_logs/README.md
+++ b/modules/config_logs/README.md
@@ -191,10 +191,6 @@ The following outputs are exported:
 
 Description: The name of the config resource.
 
-### <a name="output_resource"></a> [resource](#output\_resource)
-
-Description: The full resource object.
-
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The resource ID of the config resource.

--- a/modules/config_logs/outputs.tf
+++ b/modules/config_logs/outputs.tf
@@ -3,12 +3,6 @@ output "name" {
   value       = azapi_update_resource.this.name
 }
 
-output "resource" {
-  description = "The full resource object."
-  # tflint-ignore: no_entire_resource_output_tffr2
-  value = azapi_update_resource.this
-}
-
 output "resource_id" {
   description = "The resource ID of the config resource."
   value       = azapi_update_resource.this.id

--- a/modules/config_metadata/README.md
+++ b/modules/config_metadata/README.md
@@ -133,10 +133,6 @@ Default: `null`
 
 The following outputs are exported:
 
-### <a name="output_resource"></a> [resource](#output\_resource)
-
-Description: The full resource object.
-
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The resource ID of the config resource.

--- a/modules/config_metadata/outputs.tf
+++ b/modules/config_metadata/outputs.tf
@@ -1,9 +1,3 @@
-output "resource" {
-  description = "The full resource object."
-  # tflint-ignore: no_entire_resource_output_tffr2
-  value = azapi_resource_action.this
-}
-
 output "resource_id" {
   description = "The resource ID of the config resource."
   value       = azapi_resource_action.this.resource_id

--- a/modules/config_slotconfignames/README.md
+++ b/modules/config_slotconfignames/README.md
@@ -136,10 +136,6 @@ The following outputs are exported:
 
 Description: The name of the config resource.
 
-### <a name="output_resource"></a> [resource](#output\_resource)
-
-Description: The full resource object.
-
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The resource ID of the config resource.

--- a/modules/config_slotconfignames/outputs.tf
+++ b/modules/config_slotconfignames/outputs.tf
@@ -3,12 +3,6 @@ output "name" {
   value       = azapi_update_resource.this.name
 }
 
-output "resource" {
-  description = "The full resource object."
-  # tflint-ignore: no_entire_resource_output_tffr2
-  value = azapi_update_resource.this
-}
-
 output "resource_id" {
   description = "The resource ID of the config resource."
   value       = azapi_update_resource.this.id

--- a/modules/extensions_zipdeploy/README.md
+++ b/modules/extensions_zipdeploy/README.md
@@ -137,10 +137,6 @@ The following outputs are exported:
 
 Description: The name of the deploy action.
 
-### <a name="output_resource"></a> [resource](#output\_resource)
-
-Description: The full resource object.
-
 ## Modules
 
 No modules.

--- a/modules/extensions_zipdeploy/outputs.tf
+++ b/modules/extensions_zipdeploy/outputs.tf
@@ -2,9 +2,3 @@ output "name" {
   description = "The name of the deploy action."
   value       = "onedeploy"
 }
-
-output "resource" {
-  description = "The full resource object."
-  # tflint-ignore: no_entire_resource_output_tffr2
-  value = azapi_resource_action.this
-}

--- a/modules/hostname_binding/README.md
+++ b/modules/hostname_binding/README.md
@@ -144,10 +144,6 @@ The following outputs are exported:
 
 Description: The hostname binding name.
 
-### <a name="output_resource"></a> [resource](#output\_resource)
-
-Description: The full resource object.
-
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The resource ID of the hostname binding.

--- a/modules/hostname_binding/outputs.tf
+++ b/modules/hostname_binding/outputs.tf
@@ -3,12 +3,6 @@ output "name" {
   value       = azapi_resource.this.name
 }
 
-output "resource" {
-  description = "The full resource object."
-  # tflint-ignore: no_entire_resource_output_tffr2
-  value = azapi_resource.this
-}
-
 output "resource_id" {
   description = "The resource ID of the hostname binding."
   value       = azapi_resource.this.id

--- a/modules/publishing_credential_policy/README.md
+++ b/modules/publishing_credential_policy/README.md
@@ -145,10 +145,6 @@ The following outputs are exported:
 
 Description: The name of the publishing credential policy.
 
-### <a name="output_resource"></a> [resource](#output\_resource)
-
-Description: The full resource object.
-
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The resource ID of the publishing credential policy.

--- a/modules/publishing_credential_policy/outputs.tf
+++ b/modules/publishing_credential_policy/outputs.tf
@@ -3,12 +3,6 @@ output "name" {
   value       = azapi_update_resource.this.name
 }
 
-output "resource" {
-  description = "The full resource object."
-  # tflint-ignore: no_entire_resource_output_tffr2
-  value = azapi_update_resource.this
-}
-
 output "resource_id" {
   description = "The resource ID of the publishing credential policy."
   value       = azapi_update_resource.this.id

--- a/modules/slot/README.md
+++ b/modules/slot/README.md
@@ -984,25 +984,17 @@ The following outputs are exported:
 
 Description: The principal ID of the system-assigned managed identity (if enabled).
 
-### <a name="output_lock"></a> [lock](#output\_lock)
-
-Description: The lock resource for this slot.
-
 ### <a name="output_name"></a> [name](#output\_name)
 
 Description: The name of the deployment slot.
 
-### <a name="output_private_endpoints"></a> [private\_endpoints](#output\_private\_endpoints)
-
-Description: The private endpoints created for this slot.
-
-### <a name="output_resource"></a> [resource](#output\_resource)
-
-Description: The full slot resource object.
-
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The resource ID of the deployment slot.
+
+### <a name="output_server_farm_resource_id"></a> [server\_farm\_resource\_id](#output\_server\_farm\_resource\_id)
+
+Description: The normalized service plan resource ID configured on the deployment slot.
 
 ## Modules
 

--- a/modules/slot/outputs.tf
+++ b/modules/slot/outputs.tf
@@ -3,29 +3,17 @@ output "identity_principal_id" {
   value       = try(azapi_resource.this.output.identity.principalId, null)
 }
 
-output "lock" {
-  description = "The lock resource for this slot."
-  value       = one(values(azapi_resource.lock))
-}
-
 output "name" {
   description = "The name of the deployment slot."
   value       = azapi_resource.this.name
 }
 
-output "private_endpoints" {
-  description = "The private endpoints created for this slot."
-  # tflint-ignore: no_entire_resource_output_tffr2
-  value = azapi_resource.private_endpoint
-}
-
-output "resource" {
-  description = "The full slot resource object."
-  # tflint-ignore: no_entire_resource_output_tffr2
-  value = azapi_resource.this
-}
-
 output "resource_id" {
   description = "The resource ID of the deployment slot."
   value       = azapi_resource.this.id
+}
+
+output "server_farm_resource_id" {
+  description = "The normalized service plan resource ID configured on the deployment slot."
+  value       = azapi_resource.this.body.properties.serverFarmId
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,17 +13,13 @@ DESCRIPTION
   value       = try(azapi_resource.this.output.properties.customDomainVerificationId, null)
 }
 
-output "deployment_slot_locks" {
-  description = "The locks of the deployment slots."
-  value = length(module.slot) > 0 ? {
-    for k, v in module.slot : k => v.lock if v.lock != null
-  } : null
-}
-
 output "deployment_slots" {
-  description = "The deployment slots."
+  description = "A map of deployment slots with their names and resource IDs. The map key is the supplied input to var.deployment_slots."
   value = length(module.slot) > 0 ? {
-    for k, v in module.slot : k => v.resource
+    for k, v in module.slot : k => {
+      name        = v.name
+      resource_id = v.resource_id
+    }
   } : null
 }
 
@@ -53,13 +49,8 @@ output "os_type" {
   value       = var.os_type
 }
 
-output "private_endpoints" {
-  description = "A map of private endpoints. The map key is the supplied input to var.private_endpoints."
-  value       = length(azapi_resource.private_endpoint) > 0 ? azapi_resource.private_endpoint : null
-}
-
-# Module owners should include the full resource via a 'resource' output
-# https://azure.github.io/Azure-Verified-Modules/specs/terraform/#id-tffr2---category-outputs---additional-terraform-outputs
+# Compatibility exception: polymind-inc/terraform-azurerm-acmebot pins ~> 0.22.0
+# and re-exports this value.
 output "resource" {
   description = "This is the full output for the resource."
   sensitive   = true
@@ -71,16 +62,6 @@ output "resource_id" {
   description = "The resource ID of the App Service."
   sensitive   = true
   value       = azapi_resource.this.id
-}
-
-output "resource_lock" {
-  description = "The locks of the resources."
-  value       = length(azapi_resource.lock) > 0 ? azapi_resource.lock : null
-}
-
-output "resource_private_endpoints" {
-  description = "A map of private endpoints. The map key is the supplied input to var.private_endpoints. The map value is the entire azapi_resource."
-  value       = length(azapi_resource.private_endpoint) > 0 ? azapi_resource.private_endpoint : null
 }
 
 output "resource_uri" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -49,8 +49,13 @@ output "os_type" {
   value       = var.os_type
 }
 
-# Compatibility exception: polymind-inc/terraform-azurerm-acmebot pins ~> 0.22.0
-# and re-exports this value.
+# Compatibility exceptions: polymind-inc/terraform-azurerm-acmebot pins ~> 0.22.0
+# and consumes these provider-backed outputs.
+output "private_endpoints" {
+  description = "A map of private endpoints. The map key is the supplied input to var.private_endpoints."
+  value       = length(azapi_resource.private_endpoint) > 0 ? azapi_resource.private_endpoint : null
+}
+
 output "resource" {
   description = "This is the full output for the resource."
   sensitive   = true

--- a/tests/unit/acmebot_output_compatibility.tftest.hcl
+++ b/tests/unit/acmebot_output_compatibility.tftest.hcl
@@ -1,0 +1,48 @@
+mock_provider "azapi" {
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg/providers/Microsoft.Web/sites/unit-test-site"
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {}
+mock_provider "time" {}
+
+variables {
+  enable_telemetry         = false
+  location                 = "eastus"
+  name                     = "unit-test-site"
+  parent_id                = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg"
+  service_plan_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg/providers/Microsoft.Web/serverFarms/unit-test-plan"
+  private_endpoints = {
+    acmebot = {
+      name               = "acmebot-private-endpoint"
+      subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg/providers/Microsoft.Network/virtualNetworks/unit-test-vnet/subnets/unit-test-subnet"
+    }
+  }
+}
+
+run "preserves_acmebot_output_contract" {
+  command = apply
+
+  assert {
+    condition     = output.resource.name == "unit-test-site"
+    error_message = "The root resource output must remain available to polymind-inc/terraform-azurerm-acmebot."
+  }
+
+  assert {
+    condition = {
+      for key, private_endpoint in coalesce(output.private_endpoints, {}) : key => {
+        name        = private_endpoint.name
+        resource_id = private_endpoint.id
+      }
+      } == {
+      acmebot = {
+        name        = "acmebot-private-endpoint"
+        resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg/providers/Microsoft.Web/sites/unit-test-site"
+      }
+    }
+    error_message = "The private endpoint output must retain the name and ID projection consumed by polymind-inc/terraform-azurerm-acmebot."
+  }
+}

--- a/tests/unit/server_farm_id_casing.tftest.hcl
+++ b/tests/unit/server_farm_id_casing.tftest.hcl
@@ -84,8 +84,8 @@ run "slot_normalizes_the_inherited_service_plan_resource_id" {
   }
 
   assert {
-    condition     = module.slot["staging"].resource.body.properties.serverFarmId == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg/providers/Microsoft.Web/serverfarms/unit-test-plan"
-    error_message = "A slot inheriting the site's plan ID should get the same normalization, got `${module.slot["staging"].resource.body.properties.serverFarmId}`."
+    condition     = module.slot["staging"].server_farm_resource_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg/providers/Microsoft.Web/serverfarms/unit-test-plan"
+    error_message = "A slot inheriting the site's plan ID should get the same normalization, got `${module.slot["staging"].server_farm_resource_id}`."
   }
 }
 
@@ -109,8 +109,8 @@ run "slot_normalizes_its_own_server_farm_id_override" {
   }
 
   assert {
-    condition     = module.slot["staging"].resource.body.properties.serverFarmId == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg/providers/Microsoft.Web/serverfarms/slot-plan"
-    error_message = "A slot's `server_farm_id` override should be normalized too, not just the inherited ID, got `${module.slot["staging"].resource.body.properties.serverFarmId}`."
+    condition     = module.slot["staging"].server_farm_resource_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg/providers/Microsoft.Web/serverfarms/slot-plan"
+    error_message = "A slot's `server_farm_id` override should be normalized too, not just the inherited ID, got `${module.slot["staging"].server_farm_resource_id}`."
   }
 }
 
@@ -136,8 +136,8 @@ run "slot_normalizes_a_lowercase_provider_namespace" {
   }
 
   assert {
-    condition     = module.slot["staging"].resource.body.properties.serverFarmId == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg/providers/Microsoft.Web/serverfarms/slot-plan"
-    error_message = "A hand-written `microsoft.web` namespace should be normalized back to `Microsoft.Web`, got `${module.slot["staging"].resource.body.properties.serverFarmId}`."
+    condition     = module.slot["staging"].server_farm_resource_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg/providers/Microsoft.Web/serverfarms/slot-plan"
+    error_message = "A hand-written `microsoft.web` namespace should be normalized back to `Microsoft.Web`, got `${module.slot["staging"].server_farm_resource_id}`."
   }
 }
 
@@ -161,7 +161,7 @@ run "slot_preserves_a_resource_group_named_server_farms" {
   }
 
   assert {
-    condition     = module.slot["staging"].resource.body.properties.serverFarmId == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serverFarms/providers/Microsoft.Web/serverfarms/serverFarms"
-    error_message = "The slot normalization must also leave a resource group or plan named `serverFarms` alone, got `${module.slot["staging"].resource.body.properties.serverFarmId}`."
+    condition     = module.slot["staging"].server_farm_resource_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serverFarms/providers/Microsoft.Web/serverfarms/serverFarms"
+    error_message = "The slot normalization must also leave a resource group or plan named `serverFarms` alone, got `${module.slot["staging"].server_farm_resource_id}`."
   }
 }


### PR DESCRIPTION
The pinned lint baseline in #363 exposed a separate, breaking output-contract problem. I split this work into a dependent PR so the lint compatibility fix stays reviewable and this v0.23 cleanup can carry its own compatibility boundary.

This removes unused whole-resource outputs from the certificate and configuration/action submodules, plus the unused root `deployment_slot_locks`, `resource_lock`, and `resource_private_endpoints` outputs. It narrows `deployment_slots` to `{ name, resource_id }` and adds the slot-level `server_farm_resource_id` output used by the existing casing coverage.

TFFR2 recommends computed, discrete outputs instead of entire provider resource objects. That boundary avoids exposing sensitive data and insulates callers from provider or API schema changes.

This does not change any Azure resource, request body, lifecycle behavior, or input. The changes are limited to Terraform outputs, their generated documentation, and compatibility coverage.

The root `resource` and `private_endpoints` outputs remain as narrow compatibility exceptions. `polymind-inc/terraform-azurerm-acmebot` v1.0.0-preview3 consumes both and currently pins this module to `~> 0.22.0`. Terraform cannot declaratively migrate downstream module output references: `moved` blocks migrate state addresses, not expressions in a caller's configuration. Removing these outputs therefore requires a coordinated acmebot release rather than an automatic migration here. `tests/unit/acmebot_output_compatibility.tftest.hcl` preserves the demonstrated contracts.

Validation used Avm.Authoring 0.10.1 with `AVM_HOME=C:\a`: `avm transform`, `avm format`, `avm docs`, `avm test`, `avm test unit` (22/22 runs), and the clean-worktree `avm pr-check`. The final tree also matches the previously approved output-cleanup head `63f74fc32d088981691f16c0262c3da05785b013` exactly.

Removal of the two acmebot-consumed root outputs is deliberately deferred until a compatible acmebot release is available.

_Drafted by GPT-5.6 Sol._