### PR TITLE
fix!: reject explicit null on collection variables with non-null defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1979,6 +1979,8 @@ Default: `{}`
 
 Description: Retry configuration for the AzAPI resources declared by this module and its submodules. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
 
+This variable is deliberately nullable: setting it to `null` is meaningful and distinct from the default. `null` disables retries entirely on every AzAPI resource this module and its submodules declare, whereas leaving it unset (or passing `{}`) applies the default retry-on-conflict behavior described below.
+
 - `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
 - `interval_seconds` - (Optional) The initial interval in seconds between retries.
 - `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.

--- a/modules/site_config_helpers/variables.tf
+++ b/modules/site_config_helpers/variables.tf
@@ -18,4 +18,5 @@ variable "site_config" {
   type        = any
   default     = {}
   description = "The site configuration object to transform. Uses `any` type as this is an internal helper; callers validate types."
+  nullable    = false
 }

--- a/modules/slot/variables.tf
+++ b/modules/slot/variables.tf
@@ -116,6 +116,7 @@ variable "connection_strings" {
   }))
   default     = {}
   description = "Connection strings for the slot."
+  nullable    = false
 }
 
 variable "container_size" {
@@ -672,6 +673,7 @@ variable "site_config" {
   })
   default     = {}
   description = "Site configuration for the deployment slot."
+  nullable    = false
 }
 
 variable "ssh_enabled" {
@@ -703,6 +705,7 @@ variable "storage_shares_to_mount" {
   }))
   default     = {}
   description = "Storage shares to mount on the slot."
+  nullable    = false
 }
 
 variable "tags" {

--- a/tests/unit/nullable_collection_variables.tftest.hcl
+++ b/tests/unit/nullable_collection_variables.tftest.hcl
@@ -1,0 +1,176 @@
+# Unit tests for issue #373: collection variables with a non-null default that
+# were still nullable, so an explicit `null` reached the module body.
+#
+# Each run passes `null` for one variable and asserts the variable resolved to
+# its declared default instead. Before `nullable = false` these plans failed
+# outright (`length()`/`for_each` rejecting null, an attribute lookup on null,
+# or a submodule reporting "required variable may not be set to null" against a
+# variable the caller never sees). The assertions are deliberately written as
+# `var.x != null && length(var.x) == 0` rather than `var.x == {}`, because an
+# empty `map(object(...))` and an empty object literal compare unequal.
+#
+# `retry` is intentionally excluded from that treatment. It is the one variable
+# in this set where `null` already planned cleanly and means something distinct
+# from the default: it disables retries on every AzAPI resource this module
+# declares. The two `retry` runs pin both halves of that contract.
+#
+# These runs use `command = plan`. Per the note in
+# `conditionally_required_variables.tftest.hcl` (issue #349), any run that leans
+# on variable-level evaluation has to stay on `plan`: validation happens during
+# the plan stage, so `command = apply` reports "the apply operation could not be
+# executed and so the overall test case will be marked as a failure" and fails
+# the run even when the outcome is the expected one. `plan` is enough here in
+# any case, since the regression being guarded is that these values blow up
+# while the plan graph is being built.
+
+mock_provider "azapi" {
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Web/sites/app-unit-test"
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {}
+mock_provider "time" {}
+
+variables {
+  location                 = "eastus"
+  name                     = "app-unit-test"
+  parent_id                = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+  service_plan_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Web/serverfarms/asp-test"
+  enable_telemetry         = false
+}
+
+# `always_ready` is only dereferenced when `function_app_uses_fc1` is true, so
+# the Flex Consumption inputs are required to reach the failing expression.
+run "null_always_ready_uses_default" {
+  command = plan
+
+  variables {
+    kind                              = "functionapp"
+    os_type                           = "Linux"
+    function_app_uses_fc1             = true
+    fc1_runtime_name                  = "node"
+    fc1_runtime_version               = "20"
+    storage_authentication_type       = "UserAssignedIdentity"
+    storage_container_endpoint        = "https://sttest.blob.core.windows.net/deployments"
+    storage_user_assigned_identity_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/uai-test"
+    always_ready                      = null
+  }
+
+  assert {
+    condition     = var.always_ready != null && length(var.always_ready) == 0
+    error_message = "An explicit null for always_ready should resolve to the empty default."
+  }
+  assert {
+    condition     = local.body.properties.functionAppConfig.scaleAndConcurrency.alwaysReady == null
+    error_message = "An empty always_ready should omit alwaysReady from the Flex Consumption body."
+  }
+}
+
+run "null_backup_uses_default" {
+  command = plan
+
+  variables {
+    backup = null
+  }
+
+  assert {
+    condition     = var.backup != null && length(var.backup) == 0
+    error_message = "An explicit null for backup should resolve to the empty default."
+  }
+}
+
+run "null_connection_strings_uses_default" {
+  command = plan
+
+  variables {
+    connection_strings = null
+  }
+
+  assert {
+    condition     = var.connection_strings != null && length(var.connection_strings) == 0
+    error_message = "An explicit null for connection_strings should resolve to the empty default."
+  }
+}
+
+run "null_site_config_uses_default" {
+  command = plan
+
+  variables {
+    site_config = null
+  }
+
+  assert {
+    condition     = var.site_config != null && var.site_config.always_on == true
+    error_message = "An explicit null for site_config should resolve to the default object."
+  }
+}
+
+run "null_slots_storage_shares_sensitive_values_uses_default" {
+  command = plan
+
+  variables {
+    slots_storage_shares_to_mount_sensitive_values = null
+    deployment_slots = {
+      staging = {}
+    }
+  }
+
+  assert {
+    condition     = nonsensitive(var.slots_storage_shares_to_mount_sensitive_values) != null && length(nonsensitive(var.slots_storage_shares_to_mount_sensitive_values)) == 0
+    error_message = "An explicit null for slots_storage_shares_to_mount_sensitive_values should resolve to the empty default."
+  }
+}
+
+run "null_sticky_settings_uses_default" {
+  command = plan
+
+  variables {
+    sticky_settings = null
+  }
+
+  assert {
+    condition     = var.sticky_settings != null && length(var.sticky_settings) == 0
+    error_message = "An explicit null for sticky_settings should resolve to the empty default."
+  }
+}
+
+run "null_storage_shares_to_mount_uses_default" {
+  command = plan
+
+  variables {
+    storage_shares_to_mount = null
+  }
+
+  assert {
+    condition     = var.storage_shares_to_mount != null && length(var.storage_shares_to_mount) == 0
+    error_message = "An explicit null for storage_shares_to_mount should resolve to the empty default."
+  }
+}
+
+# `retry` stays nullable on purpose. Passing null is how a caller opts out of
+# retries entirely, and it has always planned cleanly, so forcing the default
+# back on would be a silent behavior change rather than a fix.
+run "null_retry_is_preserved" {
+  command = plan
+
+  variables {
+    retry = null
+  }
+
+  assert {
+    condition     = var.retry == null
+    error_message = "An explicit null for retry should be preserved, so that retries stay disabled."
+  }
+}
+
+run "unset_retry_uses_default" {
+  command = plan
+
+  assert {
+    condition     = var.retry != null && var.retry.interval_seconds == 10
+    error_message = "An unset retry should resolve to the default retry-on-conflict configuration."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,7 @@ A map of always-ready instances for Flex Consumption Function Apps.
 - `name`: The trigger type or function name. Valid values: `http`, `blob`, `durable`, `function:<target-function-app-name>`.
 - `instance_count`: The number of always-ready instances. Defaults to `0`.
 DESCRIPTION
+  nullable    = false
 }
 
 variable "app_service_active_slot" {
@@ -402,6 +403,7 @@ A map of backup settings for the App Service.
   - `retention_period_days` - (Optional) The number of days to retain backups.
   - `start_time` - (Optional) The start time for the backup schedule.
 DESCRIPTION
+  nullable    = false
 }
 
 variable "builtin_logging_enabled" {
@@ -499,6 +501,7 @@ A map of connection strings to assign to the App Service.
 - `type` - (Optional) The type of the connection string.
 - `value` - (Optional) The value of the connection string.
 DESCRIPTION
+  nullable    = false
 }
 
 variable "container_size" {
@@ -1786,6 +1789,8 @@ variable "retry" {
   description = <<DESCRIPTION
 Retry configuration for the AzAPI resources declared by this module and its submodules. Defaults to retrying the conflict Azure returns while another operation on the site is in progress.
 
+This variable is deliberately nullable: setting it to `null` is meaningful and distinct from the default. `null` disables retries entirely on every AzAPI resource this module and its submodules declare, whereas leaving it unset (or passing `{}`) applies the default retry-on-conflict behavior described below.
+
 - `error_message_regex` - (Optional) A list of regular expressions matched against error messages. A match triggers a retry.
 - `interval_seconds` - (Optional) The initial interval in seconds between retries.
 - `max_interval_seconds` - (Optional) The maximum interval in seconds between retries.
@@ -2200,6 +2205,7 @@ An object that configures the App Service's site configuration. These map to the
     - `physical_path` - (Optional) The physical path.
     - `virtual_path` - (Optional) The virtual path.
 DESCRIPTION
+  nullable    = false
 }
 
 variable "slot_sensitive_app_settings" {
@@ -2218,6 +2224,7 @@ A map of sensitive values (Storage Access Key) for the Storage Account SMB file 
 The key is the supplied input to `var.deployment_slots.<slot_key>.storage_shares_to_mount`.
 The value is the secret value (storage access key).
 DESCRIPTION
+  nullable    = false
   sensitive   = true
 }
 
@@ -2239,6 +2246,7 @@ A map of sticky settings to assign to the App Service.
 - `app_setting_names` - (Optional) A list of app setting names that should be sticky to the slot.
 - `connection_string_names` - (Optional) A list of connection string names that should be sticky to the slot.
 DESCRIPTION
+  nullable    = false
 }
 
 variable "storage_account_access_key" {
@@ -2338,6 +2346,7 @@ A map of Storage Account file shares to mount to the App Service.
 - `share_name` - (Required) The name of the file share.
 - `type` - (Optional) The type of storage. Defaults to `AzureFiles`.
 DESCRIPTION
+  nullable    = false
 }
 
 variable "storage_user_assigned_identity_id" {


### PR DESCRIPTION
Fixes #373

#349 added `nullable = false` to three scalar variables that declared a non-`null` default but were still nullable, so an explicit `null` got past the variable boundary and failed somewhere in the module body. That fix was scoped to what the reporter hit; the collection variables were never audited. This is that audit.

The inconsistency is the actual problem. Whether an explicit `null` shows up as a clear error, an opaque one, or works silently depends on which function touches it first. On Terraform 1.15.8, `merge(null, { a = "b" })` succeeds, `length(null)` and `keys(null)` raise "argument must not be null", and `for_each = null` produces a third message entirely. Nothing in the generated README tells a caller which of these is safe.

## What changes

Seven variables get `nullable = false`, so Terraform substitutes the default rather than propagating `null`:

| Variable | How it was consumed | Before | After |
| --- | --- | --- | --- |
| `always_ready` | `length()` in `locals.body.tf`, but only under `function_app_uses_fc1` | Worked silently for web apps; `Invalid function argument ... var.always_ready is null` the moment you switched to Flex Consumption | Empty default |
| `backup` | `for_each = var.backup` | `Invalid for_each argument` | Empty default |
| `connection_strings` | passed to `modules/config_connectionstrings`, which already had `nullable = false` | `required variable may not be set to null` naming a submodule variable the caller never sees | Empty default |
| `site_config` | attribute lookups in `locals.config.tf` | `Attempt to get attribute from null value` on an internal local | Default object |
| `slots_storage_shares_to_mount_sensitive_values` | indexed in `main.slots.tf` | Worked until a slot actually mounted a share, then `Attempt to index null value` | Empty default |
| `sticky_settings` | `length()` in `main.config.tf` | `Invalid function argument` | Empty default |
| `storage_shares_to_mount` | passed to `modules/config_azurestorageaccounts`, which already had `nullable = false` | `required variable may not be set to null` naming a submodule variable | Empty default |

Two of these were latent rather than broken: `always_ready` and `slots_storage_shares_to_mount_sensitive_values` accept `null` today and only fail once you enter the mode that dereferences them. The other five fail immediately, so their blast radius is effectively zero.

`retry` is deliberately left nullable. `retry = null` already plans cleanly and means something distinct from the default: it disables retries on every AzAPI resource this module and its submodules declare. Forcing the default back on would silently re-enable retries for anyone using it that way, which is worse than the opaque error we are fixing here. Its description now documents the distinction, and there are two tests pinning both halves of that contract.

`modules/slot` and `modules/site_config_helpers` get the matching declarations for `site_config`, `connection_strings`, and `storage_shares_to_mount` so root and submodule agree. That is consistency work rather than a fix -- the root can no longer hand them a `null`, and `site_config_helpers` guards everything with `try()` anyway.

`app_settings` is in the same category and is deliberately excluded, since #344 is fixing it concurrently and introduced the `keys()` call that made its `null` handling a hard failure.

## Tests

`tests/unit/nullable_collection_variables.tftest.hcl`, nine runs. Each passes `null` for one variable and asserts it resolved to the declared default with a clean plan. The assertions are `var.x != null && length(var.x) == 0` rather than `var.x == {}`, because an empty `map(object(...))` and an empty object literal compare unequal -- I hit that writing the first draft.

All nine use `command = plan`, and the header comment explains why: per the note #349 left in `conditionally_required_variables.tftest.hcl`, variable-level evaluation happens during the plan stage, so `command = apply` reports "the apply operation could not be executed and so the overall test case will be marked as a failure". `plan` is also sufficient here, since the regression being guarded is that these values blow up while the plan graph is being built.

I mutation-tested the suite rather than trusting it. Removing each `nullable = false` line one at a time, from a clean tree, restoring between runs:

| Mutation | Result |
| --- | --- |
| `always_ready` | 0 passed, 1 failed, 8 skipped |
| `backup` | 1 passed, 1 failed, 7 skipped |
| `connection_strings` | 2 passed, 1 failed, 6 skipped |
| `site_config` | 3 passed, 1 failed, 5 skipped |
| `slots_storage_shares_to_mount_sensitive_values` | 8 passed, 1 failed |
| `sticky_settings` | 5 passed, 1 failed, 3 skipped |
| `storage_shares_to_mount` | 6 passed, 1 failed, 2 skipped |
| `retry`, inverse: *added* `nullable = false` | 8 passed, 1 failed |

Every mutation kills exactly its own run. The skip counts differ because most reverted variables fail the plan outright, which halts the file, while the two latent ones only fail their assertion and let the rest continue -- which is itself the evidence that they were latent.

## Release classification

Per TFNFR35 this is a behavior change for anyone explicitly passing `null` today, and per SNFR17 a pre-1.0 breaking change bumps the MINOR segment, hence the `fix!:` title.

## Validation

`avm test unit` (42 runs, all pass), `avm pre-commit`, and `avm pr-check` all green locally. No `terraform apply` was run; example deployments are left to CI.

_Drafted by Claude Opus 5._
