### PR TITLE
fix: omit null nested objects from config request bodies

### DIFF
--- a/modules/config_authsettings/main.tf
+++ b/modules/config_authsettings/main.tf
@@ -1,7 +1,11 @@
 # Deprecated but kept for backward compatibility.
 # The ARM API uses flat property names (e.g. facebookAppId, microsoftAccountClientId)
-# rather than nested objects. Properties for disabled providers are set to null
-# and excluded by the azapi provider during serialization.
+# rather than nested objects. Properties for disabled providers are set to null,
+# which is safe here precisely because the body is flat: Azure either omits those
+# keys or returns them as null, and `ignore_missing_property` (on by default) keeps
+# the configured null in state either way. The nested-object form of this body would
+# not be safe, because Azure materialises absent sub-objects on read and the plan
+# would never converge — see #368 and `modules/config_authsettingsv2/locals.tf`.
 resource "azapi_update_resource" "this" {
   name      = "authsettings"
   parent_id = var.parent_id

--- a/modules/config_authsettingsv2/locals.tf
+++ b/modules/config_authsettingsv2/locals.tf
@@ -1,4 +1,7 @@
 locals {
+  # Shorthands for the deepest path in the schema, so the merge below stays readable.
+  aad                              = try(var.identity_providers.azure_active_directory, null)
+  aad_default_authorization_policy = try(local.aad.validation.default_authorization_policy, null)
   # Build httpSettings using merge to avoid null forwardProxy key
   http_settings = merge(
     {
@@ -15,144 +18,216 @@ locals {
       }
     } : {},
   )
-  # Build identityProviders using merge to avoid null keys that cause idempotency issues
+  # Build identityProviders using merge to avoid null keys that cause idempotency issues.
+  #
+  # Every nested object is contributed by a conditional `merge` arm rather than
+  # emitted as an explicit `null`. Azure materialises an absent sub-object on read
+  # (`"allowedPrincipals": {"groups": null, "identities": null}`), so a configured
+  # `null` never matches what comes back and the plan never converges (#368). A key
+  # that is absent from `body` is not compared at all, which is what we want.
   identity_providers = var.identity_providers != null ? merge(
     var.identity_providers.apple != null ? {
-      apple = {
-        enabled = var.identity_providers.apple.enabled
-        login   = var.identity_providers.apple.login
-        registration = var.identity_providers.apple.registration != null ? {
-          clientId                = var.identity_providers.apple.registration.client_id
-          clientSecretSettingName = var.identity_providers.apple.registration.client_secret_setting_name
-        } : null
-      }
-    } : {},
-    var.identity_providers.azure_active_directory != null ? {
-      azureActiveDirectory = merge(
+      apple = merge(
         {
-          enabled           = var.identity_providers.azure_active_directory.enabled
-          isAutoProvisioned = var.identity_providers.azure_active_directory.is_auto_provisioned
-          registration = var.identity_providers.azure_active_directory.registration != null ? {
-            clientId                                      = var.identity_providers.azure_active_directory.registration.client_id
-            clientSecretCertificateIssuer                 = var.identity_providers.azure_active_directory.registration.client_secret_certificate_issuer
-            clientSecretCertificateSubjectAlternativeName = var.identity_providers.azure_active_directory.registration.client_secret_certificate_subject_alternative_name
-            clientSecretCertificateThumbprint             = var.identity_providers.azure_active_directory.registration.client_secret_certificate_thumbprint
-            clientSecretSettingName                       = var.identity_providers.azure_active_directory.registration.client_secret_setting_name
-            openIdIssuer                                  = var.identity_providers.azure_active_directory.registration.open_id_issuer
-          } : null
+          enabled = var.identity_providers.apple.enabled
         },
-        var.identity_providers.azure_active_directory.login != null ? {
-          login = {
-            disableWWWAuthenticate = var.identity_providers.azure_active_directory.login.disable_www_authenticate
-            loginParameters        = var.identity_providers.azure_active_directory.login.login_parameters
-          }
+        var.identity_providers.apple.login != null ? {
+          login = var.identity_providers.apple.login
         } : {},
-        var.identity_providers.azure_active_directory.validation != null ? {
-          validation = {
-            allowedAudiences = var.identity_providers.azure_active_directory.validation.allowed_audiences
-            defaultAuthorizationPolicy = var.identity_providers.azure_active_directory.validation.default_authorization_policy != null ? {
-              allowedApplications = var.identity_providers.azure_active_directory.validation.default_authorization_policy.allowed_applications
-              allowedPrincipals = var.identity_providers.azure_active_directory.validation.default_authorization_policy.allowed_principals != null ? {
-                groups     = var.identity_providers.azure_active_directory.validation.default_authorization_policy.allowed_principals.groups
-                identities = var.identity_providers.azure_active_directory.validation.default_authorization_policy.allowed_principals.identities
-              } : null
-            } : null
-            jwtClaimChecks = var.identity_providers.azure_active_directory.validation.jwt_claim_checks != null ? {
-              allowedClientApplications = var.identity_providers.azure_active_directory.validation.jwt_claim_checks.allowed_client_applications
-              allowedGroups             = var.identity_providers.azure_active_directory.validation.jwt_claim_checks.allowed_groups
-            } : null
+        var.identity_providers.apple.registration != null ? {
+          registration = {
+            clientId                = var.identity_providers.apple.registration.client_id
+            clientSecretSettingName = var.identity_providers.apple.registration.client_secret_setting_name
           }
         } : {},
       )
     } : {},
+    local.aad != null ? {
+      azureActiveDirectory = merge(
+        {
+          enabled           = local.aad.enabled
+          isAutoProvisioned = local.aad.is_auto_provisioned
+        },
+        local.aad.registration != null ? {
+          registration = {
+            clientId                                      = local.aad.registration.client_id
+            clientSecretCertificateIssuer                 = local.aad.registration.client_secret_certificate_issuer
+            clientSecretCertificateSubjectAlternativeName = local.aad.registration.client_secret_certificate_subject_alternative_name
+            clientSecretCertificateThumbprint             = local.aad.registration.client_secret_certificate_thumbprint
+            clientSecretSettingName                       = local.aad.registration.client_secret_setting_name
+            openIdIssuer                                  = local.aad.registration.open_id_issuer
+          }
+        } : {},
+        local.aad.login != null ? {
+          login = {
+            disableWWWAuthenticate = local.aad.login.disable_www_authenticate
+            loginParameters        = local.aad.login.login_parameters
+          }
+        } : {},
+        local.aad.validation != null ? {
+          validation = merge(
+            {
+              allowedAudiences = local.aad.validation.allowed_audiences
+            },
+            local.aad_default_authorization_policy != null ? {
+              defaultAuthorizationPolicy = merge(
+                {
+                  allowedApplications = local.aad_default_authorization_policy.allowed_applications
+                },
+                local.aad_default_authorization_policy.allowed_principals != null ? {
+                  allowedPrincipals = {
+                    groups     = local.aad_default_authorization_policy.allowed_principals.groups
+                    identities = local.aad_default_authorization_policy.allowed_principals.identities
+                  }
+                } : {},
+              )
+            } : {},
+            local.aad.validation.jwt_claim_checks != null ? {
+              jwtClaimChecks = {
+                allowedClientApplications = local.aad.validation.jwt_claim_checks.allowed_client_applications
+                allowedGroups             = local.aad.validation.jwt_claim_checks.allowed_groups
+              }
+            } : {},
+          )
+        } : {},
+      )
+    } : {},
     var.identity_providers.azure_static_web_apps != null ? {
-      azureStaticWebApps = {
-        enabled = var.identity_providers.azure_static_web_apps.enabled
-        registration = var.identity_providers.azure_static_web_apps.registration != null ? {
-          clientId = var.identity_providers.azure_static_web_apps.registration.client_id
-        } : null
-      }
+      azureStaticWebApps = merge(
+        {
+          enabled = var.identity_providers.azure_static_web_apps.enabled
+        },
+        var.identity_providers.azure_static_web_apps.registration != null ? {
+          registration = {
+            clientId = var.identity_providers.azure_static_web_apps.registration.client_id
+          }
+        } : {},
+      )
     } : {},
     var.identity_providers.custom_open_id_connect_providers != null ? {
       customOpenIdConnectProviders = {
-        for k, v in var.identity_providers.custom_open_id_connect_providers : k => {
-          enabled = v.enabled
-          login = v.login != null ? {
-            nameClaimType = v.login.name_claim_type
-            scopes        = v.login.scopes
-          } : null
-          registration = v.registration != null ? {
-            clientId = v.registration.client_id
-            clientCredential = v.registration.client_credential != null ? {
-              method                  = v.registration.client_credential.method
-              clientSecretSettingName = v.registration.client_credential.client_secret_setting_name
-            } : null
-            openIdConnectConfiguration = v.registration.open_id_connect_configuration != null ? {
-              authorizationEndpoint        = v.registration.open_id_connect_configuration.authorization_endpoint
-              certificationUri             = v.registration.open_id_connect_configuration.certification_uri
-              issuer                       = v.registration.open_id_connect_configuration.issuer
-              tokenEndpoint                = v.registration.open_id_connect_configuration.token_endpoint
-              wellKnownOpenIdConfiguration = v.registration.open_id_connect_configuration.well_known_open_id_configuration
-            } : null
-          } : null
-        }
+        for k, v in var.identity_providers.custom_open_id_connect_providers : k => merge(
+          {
+            enabled = v.enabled
+          },
+          v.login != null ? {
+            login = {
+              nameClaimType = v.login.name_claim_type
+              scopes        = v.login.scopes
+            }
+          } : {},
+          v.registration != null ? {
+            registration = merge(
+              {
+                clientId = v.registration.client_id
+              },
+              v.registration.client_credential != null ? {
+                clientCredential = {
+                  method                  = v.registration.client_credential.method
+                  clientSecretSettingName = v.registration.client_credential.client_secret_setting_name
+                }
+              } : {},
+              v.registration.open_id_connect_configuration != null ? {
+                openIdConnectConfiguration = {
+                  authorizationEndpoint        = v.registration.open_id_connect_configuration.authorization_endpoint
+                  certificationUri             = v.registration.open_id_connect_configuration.certification_uri
+                  issuer                       = v.registration.open_id_connect_configuration.issuer
+                  tokenEndpoint                = v.registration.open_id_connect_configuration.token_endpoint
+                  wellKnownOpenIdConfiguration = v.registration.open_id_connect_configuration.well_known_open_id_configuration
+                }
+              } : {},
+            )
+          } : {},
+        )
       }
     } : {},
     var.identity_providers.facebook != null ? {
-      facebook = {
-        enabled         = var.identity_providers.facebook.enabled
-        graphApiVersion = var.identity_providers.facebook.graph_api_version
-        login           = var.identity_providers.facebook.login
-        registration = var.identity_providers.facebook.registration != null ? {
-          appId                = var.identity_providers.facebook.registration.app_id
-          appSecretSettingName = var.identity_providers.facebook.registration.app_secret_setting_name
-        } : null
-      }
+      facebook = merge(
+        {
+          enabled         = var.identity_providers.facebook.enabled
+          graphApiVersion = var.identity_providers.facebook.graph_api_version
+        },
+        var.identity_providers.facebook.login != null ? {
+          login = var.identity_providers.facebook.login
+        } : {},
+        var.identity_providers.facebook.registration != null ? {
+          registration = {
+            appId                = var.identity_providers.facebook.registration.app_id
+            appSecretSettingName = var.identity_providers.facebook.registration.app_secret_setting_name
+          }
+        } : {},
+      )
     } : {},
     var.identity_providers.github != null ? {
-      gitHub = {
-        enabled = var.identity_providers.github.enabled
-        login   = var.identity_providers.github.login
-        registration = var.identity_providers.github.registration != null ? {
-          clientId                = var.identity_providers.github.registration.client_id
-          clientSecretSettingName = var.identity_providers.github.registration.client_secret_setting_name
-        } : null
-      }
+      gitHub = merge(
+        {
+          enabled = var.identity_providers.github.enabled
+        },
+        var.identity_providers.github.login != null ? {
+          login = var.identity_providers.github.login
+        } : {},
+        var.identity_providers.github.registration != null ? {
+          registration = {
+            clientId                = var.identity_providers.github.registration.client_id
+            clientSecretSettingName = var.identity_providers.github.registration.client_secret_setting_name
+          }
+        } : {},
+      )
     } : {},
     var.identity_providers.google != null ? {
-      google = {
-        enabled = var.identity_providers.google.enabled
-        login   = var.identity_providers.google.login
-        registration = var.identity_providers.google.registration != null ? {
-          clientId                = var.identity_providers.google.registration.client_id
-          clientSecretSettingName = var.identity_providers.google.registration.client_secret_setting_name
-        } : null
-        validation = var.identity_providers.google.validation != null ? {
-          allowedAudiences = var.identity_providers.google.validation.allowed_audiences
-        } : null
-      }
+      google = merge(
+        {
+          enabled = var.identity_providers.google.enabled
+        },
+        var.identity_providers.google.login != null ? {
+          login = var.identity_providers.google.login
+        } : {},
+        var.identity_providers.google.registration != null ? {
+          registration = {
+            clientId                = var.identity_providers.google.registration.client_id
+            clientSecretSettingName = var.identity_providers.google.registration.client_secret_setting_name
+          }
+        } : {},
+        var.identity_providers.google.validation != null ? {
+          validation = {
+            allowedAudiences = var.identity_providers.google.validation.allowed_audiences
+          }
+        } : {},
+      )
     } : {},
     var.identity_providers.legacy_microsoft_account != null ? {
-      legacyMicrosoftAccount = {
-        enabled = var.identity_providers.legacy_microsoft_account.enabled
-        login   = var.identity_providers.legacy_microsoft_account.login
-        registration = var.identity_providers.legacy_microsoft_account.registration != null ? {
-          clientId                = var.identity_providers.legacy_microsoft_account.registration.client_id
-          clientSecretSettingName = var.identity_providers.legacy_microsoft_account.registration.client_secret_setting_name
-        } : null
-        validation = var.identity_providers.legacy_microsoft_account.validation != null ? {
-          allowedAudiences = var.identity_providers.legacy_microsoft_account.validation.allowed_audiences
-        } : null
-      }
+      legacyMicrosoftAccount = merge(
+        {
+          enabled = var.identity_providers.legacy_microsoft_account.enabled
+        },
+        var.identity_providers.legacy_microsoft_account.login != null ? {
+          login = var.identity_providers.legacy_microsoft_account.login
+        } : {},
+        var.identity_providers.legacy_microsoft_account.registration != null ? {
+          registration = {
+            clientId                = var.identity_providers.legacy_microsoft_account.registration.client_id
+            clientSecretSettingName = var.identity_providers.legacy_microsoft_account.registration.client_secret_setting_name
+          }
+        } : {},
+        var.identity_providers.legacy_microsoft_account.validation != null ? {
+          validation = {
+            allowedAudiences = var.identity_providers.legacy_microsoft_account.validation.allowed_audiences
+          }
+        } : {},
+      )
     } : {},
     var.identity_providers.twitter != null ? {
-      twitter = {
-        enabled = var.identity_providers.twitter.enabled
-        registration = var.identity_providers.twitter.registration != null ? {
-          consumerKey               = var.identity_providers.twitter.registration.consumer_key
-          consumerSecretSettingName = var.identity_providers.twitter.registration.consumer_secret_setting_name
-        } : null
-      }
+      twitter = merge(
+        {
+          enabled = var.identity_providers.twitter.enabled
+        },
+        var.identity_providers.twitter.registration != null ? {
+          registration = {
+            consumerKey               = var.identity_providers.twitter.registration.consumer_key
+            consumerSecretSettingName = var.identity_providers.twitter.registration.consumer_secret_setting_name
+          }
+        } : {},
+      )
     } : {},
   ) : null
   # Build login section using merge to avoid null keys

--- a/modules/config_authsettingsv2/main.tf
+++ b/modules/config_authsettingsv2/main.tf
@@ -16,9 +16,11 @@ resource "azapi_update_resource" "this" {
           requireAuthentication       = var.require_authentication
           unauthenticatedClientAction = var.unauthenticated_client_action
         }
-        httpSettings      = local.http_settings
-        identityProviders = local.identity_providers
+        httpSettings = local.http_settings
       },
+      local.identity_providers != null ? {
+        identityProviders = local.identity_providers
+      } : {},
       local.login != null ? {
         login = local.login
       } : {},

--- a/modules/config_authsettingsv2/tests/unit/null_nested_objects.tftest.hcl
+++ b/modules/config_authsettingsv2/tests/unit/null_nested_objects.tftest.hcl
@@ -1,0 +1,151 @@
+// Regression coverage for #368: every plan after a successful apply proposed
+// rewriting `authsettingsV2`, because the module emitted an explicit `null` for
+// nested objects the caller had not supplied. Azure does not persist those
+// nulls — a GET returns the sub-object materialised with null members, so
+// `{"groups": null, "identities": null}` comes back where the configuration says
+// `null`, and the two never reconcile.
+//
+// The fix the reporter proposed, `ignore_null_property = true`, is not available
+// here: the AzAPI provider only offers that argument on `azapi_resource`, not on
+// `azapi_update_resource`, in 2.12 (the current release). So the null is kept out
+// of `body` in HCL instead, using the same conditional `merge` idiom the rest of
+// this file already used for `httpSettings` and `login`.
+//
+// That makes these assertions stronger than the equivalent ones in
+// `modules/certificate/tests/unit/host_names.tftest.hcl`. There, the omission is
+// the provider's own serialisation step, which `mock_provider` never reaches, so
+// the test can only pin the attribute that opts into it. Here the omission is
+// ours and happens while the body is built, so the absence of the key is
+// directly observable on the resource.
+
+mock_provider "azapi" {}
+
+variables {
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg/providers/Microsoft.Web/sites/unit-test-site"
+}
+
+// The reporter's configuration, reduced to the part that matters: Azure AD is
+// configured with a validation block, but neither `allowed_principals` nor
+// `jwt_claim_checks` is supplied.
+run "unsupplied_nested_objects_are_absent_from_the_body" {
+  command = apply
+
+  variables {
+    auth_enabled                  = true
+    require_authentication        = true
+    unauthenticated_client_action = "Return401"
+
+    identity_providers = {
+      azure_active_directory = {
+        enabled = true
+        registration = {
+          client_id      = "00000000-0000-0000-0000-000000000000"
+          open_id_issuer = "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0"
+        }
+        validation = {
+          allowed_audiences = ["api://00000000-0000-0000-0000-000000000000"]
+          default_authorization_policy = {
+            allowed_applications = ["00000000-0000-0000-0000-000000000000"]
+          }
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = !can(azapi_update_resource.this.body.properties.identityProviders.azureActiveDirectory.validation.defaultAuthorizationPolicy.allowedPrincipals)
+    error_message = "`allowedPrincipals` must be absent from the body when `allowed_principals` is not supplied. Emitted as null, Azure returns `{groups: null, identities: null}` on the next read and the plan never converges (#368)."
+  }
+
+  assert {
+    condition     = !can(azapi_update_resource.this.body.properties.identityProviders.azureActiveDirectory.validation.jwtClaimChecks)
+    error_message = "`jwtClaimChecks` must be absent from the body when `jwt_claim_checks` is not supplied (#368)."
+  }
+
+  assert {
+    condition     = !can(azapi_update_resource.this.body.properties.identityProviders.azureActiveDirectory.login)
+    error_message = "`login` must be absent from the `azureActiveDirectory` body when no login block is supplied (#368)."
+  }
+
+  // Omitting the nulls must not take the supplied configuration with it. These
+  // are the siblings of the keys dropped above, at every level of the nesting
+  // that changed.
+  assert {
+    condition     = try(join(",", tolist(nonsensitive(azapi_update_resource.this.body.properties.identityProviders.azureActiveDirectory.validation.defaultAuthorizationPolicy.allowedApplications))) == "00000000-0000-0000-0000-000000000000", false)
+    error_message = "`allowedApplications` must survive alongside the omitted `allowedPrincipals`."
+  }
+
+  assert {
+    condition     = try(join(",", tolist(nonsensitive(azapi_update_resource.this.body.properties.identityProviders.azureActiveDirectory.validation.allowedAudiences))) == "api://00000000-0000-0000-0000-000000000000", false)
+    error_message = "`allowedAudiences` must survive alongside the omitted `jwtClaimChecks`."
+  }
+
+  assert {
+    condition     = try(nonsensitive(azapi_update_resource.this.body.properties.identityProviders.azureActiveDirectory.registration.clientId) == "00000000-0000-0000-0000-000000000000", false)
+    error_message = "A supplied `registration` must still reach the body."
+  }
+
+  assert {
+    condition     = try(nonsensitive(azapi_update_resource.this.body.properties.identityProviders.azureActiveDirectory.enabled) == true, false)
+    error_message = "Scalar members of an emitted provider object must still reach the body. Only nested objects are omitted; null scalars are left to `ignore_missing_property`, which Azure's response shape already handles."
+  }
+}
+
+// The complement: when the caller does supply the nested objects, they must be
+// sent and keep diffing normally. This is what makes omission the right fix
+// rather than `ignore_body_changes`, which would mask drift on these paths even
+// when they are managed.
+run "supplied_nested_objects_reach_the_body" {
+  command = apply
+
+  variables {
+    identity_providers = {
+      azure_active_directory = {
+        enabled = true
+        validation = {
+          default_authorization_policy = {
+            allowed_principals = {
+              groups     = ["11111111-1111-1111-1111-111111111111"]
+              identities = ["22222222-2222-2222-2222-222222222222"]
+            }
+          }
+          jwt_claim_checks = {
+            allowed_groups = ["33333333-3333-3333-3333-333333333333"]
+          }
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = try(join(",", tolist(nonsensitive(azapi_update_resource.this.body.properties.identityProviders.azureActiveDirectory.validation.defaultAuthorizationPolicy.allowedPrincipals.groups))) == "11111111-1111-1111-1111-111111111111", false)
+    error_message = "A supplied `allowed_principals.groups` must reach the request body unchanged."
+  }
+
+  assert {
+    condition     = try(join(",", tolist(nonsensitive(azapi_update_resource.this.body.properties.identityProviders.azureActiveDirectory.validation.defaultAuthorizationPolicy.allowedPrincipals.identities))) == "22222222-2222-2222-2222-222222222222", false)
+    error_message = "A supplied `allowed_principals.identities` must reach the request body unchanged."
+  }
+
+  assert {
+    condition     = try(join(",", tolist(nonsensitive(azapi_update_resource.this.body.properties.identityProviders.azureActiveDirectory.validation.jwtClaimChecks.allowedGroups))) == "33333333-3333-3333-3333-333333333333", false)
+    error_message = "A supplied `jwt_claim_checks.allowed_groups` must reach the request body unchanged."
+  }
+}
+
+// `identityProviders` had the same problem one level higher: it was assigned
+// unconditionally from a local that is null when no providers are configured.
+run "identity_providers_omitted_entirely" {
+  command = apply
+
+  assert {
+    condition     = !can(azapi_update_resource.this.body.properties.identityProviders)
+    error_message = "`identityProviders` must be absent from the body when no identity providers are configured, for the same reason as its children (#368)."
+  }
+
+  // The unconditional half of the body is unaffected.
+  assert {
+    condition     = try(nonsensitive(azapi_update_resource.this.body.properties.platform.enabled) == false, false)
+    error_message = "Omitting `identityProviders` must not disturb the rest of the body."
+  }
+}

--- a/modules/config_backup/main.tf
+++ b/modules/config_backup/main.tf
@@ -3,18 +3,29 @@ resource "azapi_update_resource" "this" {
   parent_id = var.parent_id
   type      = var.resource_types.web_sites_config
   body = {
-    properties = {
-      backupName        = var.backup_name
-      enabled           = var.enabled
-      storageAccountUrl = var.storage_account_url
-      backupSchedule = var.schedule != null ? {
-        frequencyInterval     = var.schedule.frequency_interval
-        frequencyUnit         = var.schedule.frequency_unit
-        keepAtLeastOneBackup  = var.schedule.keep_at_least_one_backup
-        retentionPeriodInDays = var.schedule.retention_period_days
-        startTime             = var.schedule.start_time
-      } : null
-    }
+    # `backupSchedule` is contributed by a conditional `merge` arm rather than
+    # emitted as an explicit `null`, so it is absent from the request body when
+    # no schedule is configured. That is what `ignore_null_property` would do if
+    # `azapi_update_resource` offered it, and a key absent from `body` is never
+    # compared against the response. Unlike `authsettingsV2` there is no field
+    # report of Azure materialising this sub-object; this is the same construct
+    # kept consistent rather than a confirmed repro. See #368.
+    properties = merge(
+      {
+        backupName        = var.backup_name
+        enabled           = var.enabled
+        storageAccountUrl = var.storage_account_url
+      },
+      var.schedule != null ? {
+        backupSchedule = {
+          frequencyInterval     = var.schedule.frequency_interval
+          frequencyUnit         = var.schedule.frequency_unit
+          keepAtLeastOneBackup  = var.schedule.keep_at_least_one_backup
+          retentionPeriodInDays = var.schedule.retention_period_days
+          startTime             = var.schedule.start_time
+        }
+      } : {},
+    )
   }
   response_export_values = []
   retry                  = var.retry

--- a/modules/config_backup/tests/unit/null_backup_schedule.tftest.hcl
+++ b/modules/config_backup/tests/unit/null_backup_schedule.tftest.hcl
@@ -1,0 +1,92 @@
+// Companion coverage to `modules/config_authsettingsv2/tests/unit/null_nested_objects.tftest.hcl`
+// for the second body in this module that emitted a nested object as an explicit
+// `null` (#368). `schedule` is optional all the way up — the root passes `null`
+// whenever a `backup` entry omits its schedule — so `backupSchedule = null` was
+// reachable from ordinary configuration.
+//
+// Unlike `authsettingsV2` there is no field report of Azure materialising this
+// particular sub-object, so this is the prophylactic half of the fix. It is
+// behaviour-preserving either way: omitting a key is exactly what the provider's
+// own `ignore_null_property` does before it sends the request, and a key that is
+// absent from `body` is never compared against the response.
+
+mock_provider "azapi" {}
+
+variables {
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg/providers/Microsoft.Web/sites/unit-test-site"
+}
+
+run "unscheduled_backup_omits_the_schedule" {
+  command = apply
+
+  variables {
+    backup_name         = "unit-test-backup"
+    enabled             = true
+    storage_account_url = "https://unittest.blob.core.windows.net/backups?sv=stub"
+  }
+
+  assert {
+    condition     = !can(azapi_update_resource.this.body.properties.backupSchedule)
+    error_message = "`backupSchedule` must be absent from the body when no schedule is supplied, rather than emitted as null (#368)."
+  }
+
+  // The rest of the backup configuration is unconditional and must be unaffected
+  // by moving the schedule into a `merge` arm.
+  assert {
+    condition     = try(nonsensitive(azapi_update_resource.this.body.properties.backupName) == "unit-test-backup", false)
+    error_message = "`backupName` must still reach the body."
+  }
+
+  assert {
+    condition     = try(nonsensitive(azapi_update_resource.this.body.properties.enabled) == true, false)
+    error_message = "`enabled` must still reach the body."
+  }
+
+  assert {
+    condition     = try(nonsensitive(azapi_update_resource.this.body.properties.storageAccountUrl) == "https://unittest.blob.core.windows.net/backups?sv=stub", false)
+    error_message = "`storageAccountUrl` must still reach the body."
+  }
+}
+
+run "scheduled_backup_sends_the_schedule" {
+  command = apply
+
+  variables {
+    backup_name         = "unit-test-backup"
+    enabled             = true
+    storage_account_url = "https://unittest.blob.core.windows.net/backups?sv=stub"
+
+    schedule = {
+      frequency_interval       = 7
+      frequency_unit           = "Day"
+      keep_at_least_one_backup = true
+      retention_period_days    = 30
+      start_time               = "2026-01-01T00:00:00Z"
+    }
+  }
+
+  assert {
+    condition     = try(nonsensitive(azapi_update_resource.this.body.properties.backupSchedule.frequencyInterval) == 7, false)
+    error_message = "A supplied schedule must reach the request body, so a scheduled backup keeps being reconciled."
+  }
+
+  assert {
+    condition     = try(nonsensitive(azapi_update_resource.this.body.properties.backupSchedule.frequencyUnit) == "Day", false)
+    error_message = "A supplied `frequency_unit` must reach the request body unchanged."
+  }
+
+  assert {
+    condition     = try(nonsensitive(azapi_update_resource.this.body.properties.backupSchedule.keepAtLeastOneBackup) == true, false)
+    error_message = "A supplied `keep_at_least_one_backup` must reach the request body unchanged."
+  }
+
+  assert {
+    condition     = try(nonsensitive(azapi_update_resource.this.body.properties.backupSchedule.retentionPeriodInDays) == 30, false)
+    error_message = "A supplied `retention_period_days` must reach the request body unchanged."
+  }
+
+  assert {
+    condition     = try(nonsensitive(azapi_update_resource.this.body.properties.backupSchedule.startTime) == "2026-01-01T00:00:00Z", false)
+    error_message = "A supplied `start_time` must reach the request body unchanged."
+  }
+}


### PR DESCRIPTION
After a successful apply, every subsequent plan proposed rewriting `authsettingsV2`. `modules/config_authsettingsv2/locals.tf` emitted an explicit `null` for each nested object the caller had not supplied, and Azure does not persist those nulls: a GET returns the sub-object materialised with null members, so `{"groups": null, "identities": null}` comes back where the configuration says `null`. The two never reconcile, applying re-materialises them, and the next plan is byte-identical. The real cost is not the churn, it is that a permanently dirty plan hides genuine changes to the same resource.

## `ignore_null_property` does not exist on `azapi_update_resource`

#368 proposed `ignore_null_property = true`, matching `azapi_resource.this` in `main.tf` and in the slot, certificate, and hostname binding submodules. It would have failed the plan outright. The AzAPI provider declares that argument only on `azapi_resource`. `azapi_update_resource` gets `ignore_casing`, `ignore_missing_property`, and `ignore_other_items_in_list`, and nothing else, in 2.12 and in every earlier 2.x:

```
=== azapi_resource ===
ignore_body_changes, ignore_casing, ignore_missing_property, ignore_null_property, ignore_other_items_in_list
=== azapi_update_resource ===
ignore_casing, ignore_missing_property, ignore_other_items_in_list
```

That is also why the issue's table is misleading about `modules/certificate` and `modules/hostname_binding`. Both are `azapi_resource` and both already set it, from #284.

So this keeps the null out of `body` in HCL instead, using the same conditional `merge` idiom the file already used for `httpSettings`, `login`, and the top level of `identityProviders`, extended down through the nesting where the bug actually lived.

That is not an approximation of the provider argument. With `ignore_null_property`, the provider strips nulls with `RemoveNullProperty` before sending, and passes the same flag into the response-to-state walk so the stripped keys are skipped. That walk iterates the keys of the configured body:

```go
for key, value := range oldValue {   // oldValue is the configured body
    switch {
    case value == nil && option.IgnoreNullProperty:
        res[key] = nil                     // keep the null, matches config
    case newMap[key] != nil:
        res[key] = updateObjectAtPath(...) // take the response value  <-- the bug
    case option.IgnoreMissingProperty || isZeroValue(value):
        res[key] = value
    }
}
```

A key that was never emitted is never visited, so it is never compared. Request and diff both end up identical to what the argument would have produced.

## Why not the other two `ignore_*` arguments

`ignore_missing_property` is the one this is easy to confuse with, and it would not have helped. It covers the opposite direction, a property the configuration sets that the response omits, which is why it exists for credentials. Here the response is the side that has the property. It is already on by default, and it is what makes the flat bodies safe.

`ignore_body_changes` would have worked and is wrong on the merits. It silences a path unconditionally, including when the caller does manage it, and the whole point is that supplied values must keep reconciling. It is also rejected by a precondition in each of these submodules already.

## Scope is null nested objects, not null scalars

The reported plan shows only `allowedPrincipals` and `jwtClaimChecks` flapping, while unsupplied scalars such as `isAutoProvisioned` stay quiet. So Azure omits absent scalars from the response and materialises absent sub-objects, and omitted scalars are already handled correctly by `ignore_missing_property`. Stripping every null scalar as well would have been a much larger diff for no behavioral gain.

I audited all eight `azapi_update_resource` submodules rather than taking the reported one at face value, and six of them need nothing:

| Submodule | Emits a null nested object | Change |
| --- | --- | --- |
| `config_authsettingsv2` | yes, at 17 sites plus `identityProviders` itself | fixed |
| `config_backup` | yes, `backupSchedule` | fixed |
| `config_appsettings` | no, flat `map(string)` | none |
| `config_connectionstrings` | no, builds objects that are never null | none |
| `config_logs` | no, already used this idiom for every optional group | none |
| `config_slotconfignames` | no, two lists defaulting to `[]`, and non-null since #374 | none |
| `publishing_credential_policy` | no, a single bool defaulting to `false` | none |
| `config_authsettings` | no, flat by design | comment only |

`config_backup` is the one judgment call. `backupSchedule` is the only other nested object in these bodies emitted as a bare `null`, and it is reachable because `backup[*].schedule` is optional all the way up. But there is no field report of Azure materialising that particular sub-object, and I will not deploy to find out, so it is the same construct kept consistent rather than a confirmed repro. The comment there says so rather than implying evidence I do not have.

`config_authsettings` gets a corrected comment. It claimed the provider excluded its nulls during serialization, which was never true of `azapi_update_resource`. The body is safe anyway, but for the other reason, and that is now what it says.

## Upgrade impact

Not breaking, and no migration note. The keys being dropped are ones the provider was writing into state from the response while the configuration held null. The first plan after upgrading converges instead of proposing the same no-op write forever, which is the point. Nothing is sent to Azure that was not sent before.

There is no analogue to the `lifecycle { ignore_changes = [...] }` guard from #363. That guarded `response_export_values` on `azapi_resource_action`, where a changed attribute re-runs the action and `slotsswap` has real side effects. Nothing here is an action, and no action is re-run.

The trade is that an unsupplied nested object is now unmanaged rather than asserted absent. That matches every `ignore_null_property = true` resource in this module already, and the previous behavior did not assert absence either. It just never converged.

## Tests

New unit tests under `modules/config_authsettingsv2/tests/unit/` and `modules/config_backup/tests/unit/`, driving the submodules directly. No submodule output was added to make anything observable, per the reviews on #344, #346, and #350; the resource attribute is reachable without one.

These assert more than the equivalent test in `modules/certificate/tests/unit/host_names.tftest.hcl` can. There the omission is the provider's own serialisation step, which `mock_provider` never reaches, so that test can only pin the attribute that opts into it. Here the omission is ours and happens while the body is built, so the absence of the key is directly observable.

Reverting the three source files and rerunning the new tests fails 3 of 5 runs, on exactly the assertions that describe the bug, with the diagnostic naming the cause:

```
run "unsupplied_nested_objects_are_absent_from_the_body"... fail
  56:     condition     = !can(azapi_update_resource.this.body.properties.identityProviders.azureActiveDirectory.validation.defaultAuthorizationPolicy.allowedPrincipals)
    │ ...allowedPrincipals is null
  61:     condition     = !can(azapi_update_resource.this.body.properties.identityProviders.azureActiveDirectory.validation.jwtClaimChecks)
    │ ...jwtClaimChecks is null
run "identity_providers_omitted_entirely"... fail
 142:     condition     = !can(azapi_update_resource.this.body.properties.identityProviders)
    │ ...identityProviders is null
run "unscheduled_backup_omits_the_schedule"... fail
  29:     condition     = !can(azapi_update_resource.this.body.properties.backupSchedule)
    │ ...backupSchedule is null
```

The two runs that still pass are the complements, which supply the nested objects and check they reach the body unchanged. They are meant to pass both ways: they exist to prove the fix does not over-suppress, so a caller-managed `allowed_principals` or a real backup schedule keeps being reconciled.

`avm test unit` is 75 runs, 75 passed. `avm pre-commit` produced no documentation changes, which is expected since no variable or output changed. `avm pr-check` passes all 8 steps on a clean worktree.

## Not included

This does not resolve #352 and does not overlap it. That one is about `azapi_resource` bodies built from `avm-utl-interfaces` in `main.interfaces.tf` and the slot's copy of it. Those resources can take the provider argument, the question there is whether the utility module emits nulls at all, and nothing in this change touches those files.

Fixes #368

_Drafted by Claude Opus 5._
