### PR TITLE
fix!: use the documented `dotnet` worker runtime for Logic Apps

### DIFF
--- a/locals.app_settings.tf
+++ b/locals.app_settings.tf
@@ -89,9 +89,23 @@ locals {
   logic_app_settings = local.is_logic_app ? merge(
     {
       FUNCTIONS_EXTENSION_VERSION = var.logic_app_runtime_version
-      FUNCTIONS_WORKER_RUNTIME    = "node"
       AzureWebJobsStorage         = "DefaultEndpointsProtocol=https;AccountName=${var.storage_account_name};AccountKey=${var.storage_account_access_key}"
     },
+    # The Standard Logic App app settings reference documents `dotnet` as the
+    # required value: "This setting's value was previously set to `node`, but now
+    # the required value is `dotnet` for all new and existing deployed Standard
+    # logic apps. This change shouldn't affect your workflow's runtime, so
+    # everything should work the same way as before." The module shipped `node`.
+    #
+    # Guarded the same way #344 guarded WEBSITE_NODE_DEFAULT_VERSION, because
+    # module defaults merge *after* `var.app_settings` and would otherwise
+    # discard a caller's own entry without saying so. Unlike the Node version
+    # there is deliberately no root variable to null this out: Azure requires the
+    # setting, and the guard only yields when the caller has supplied a value of
+    # their own, so the key is always present.
+    !contains(local.app_settings_keys, "functions_worker_runtime") ? {
+      FUNCTIONS_WORKER_RUNTIME = "dotnet"
+    } : {},
     var.logic_app_node_version != null && !contains(local.app_settings_keys, "website_node_default_version") ? {
       WEBSITE_NODE_DEFAULT_VERSION = var.logic_app_node_version
     } : {},

--- a/tests/unit/logic_app_worker_runtime.tftest.hcl
+++ b/tests/unit/logic_app_worker_runtime.tftest.hcl
@@ -1,0 +1,169 @@
+// `local.merged_app_settings` is the map the module hands
+// `modules/config_appsettings` as its request body, so asserting on it covers
+// the behavior these runs care about without publishing an output that just
+// echoes the caller's own input back (TFFR2). This matches how
+// `tests/unit/logic_app_node_version.tftest.hcl` and
+// `tests/unit/conditionally_required_variables.tftest.hcl` assert on locals.
+
+mock_provider "azapi" {
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-avm-test/providers/Microsoft.Web/sites/logic-avm-test"
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {}
+mock_provider "time" {}
+
+variables {
+  enable_telemetry           = false
+  kind                       = "logicapp"
+  location                   = "eastus"
+  name                       = "unit-test-logic-app"
+  os_type                    = "Windows"
+  parent_id                  = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg"
+  service_plan_resource_id   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg/providers/Microsoft.Web/serverfarms/unit-test-plan"
+  storage_account_access_key = "unit-test-key"
+  storage_account_name       = "unittestsa"
+}
+
+# Issue #362. The module shipped `node`, which the app settings reference now
+# describes as the previous value; `dotnet` is required for all new and existing
+# deployed Standard Logic Apps.
+run "logic_app_defaults_to_the_documented_worker_runtime" {
+  command = apply
+
+  assert {
+    condition     = local.merged_app_settings["FUNCTIONS_WORKER_RUNTIME"] == "dotnet"
+    error_message = "A Logic App must default to the documented `dotnet` worker runtime."
+  }
+}
+
+# `FUNCTIONS_WORKER_RUNTIME` is a required setting, so unlike the Node version
+# there is no root variable that can null it out. Whatever else these runs
+# assert, the key itself is never absent from a Logic App.
+run "the_worker_runtime_is_always_present_on_a_logic_app" {
+  command = apply
+
+  variables {
+    logic_app_node_version    = null
+    logic_app_runtime_version = "~4"
+    use_extension_bundle      = false
+  }
+
+  assert {
+    condition     = contains(keys(local.merged_app_settings), "FUNCTIONS_WORKER_RUNTIME")
+    error_message = "Azure requires `FUNCTIONS_WORKER_RUNTIME` on a Standard Logic App, so no combination of inputs may drop it."
+  }
+}
+
+# The module merges its Logic App defaults after `var.app_settings`, so without
+# an explicit gate it silently overwrites whatever the consumer set — the bug
+# class #344 fixed one line above this setting. A caller mid-migration who still
+# needs `node` has nowhere else to say so.
+run "explicit_app_settings_entry_beats_the_module_default" {
+  command = apply
+
+  variables {
+    app_settings = {
+      FUNCTIONS_WORKER_RUNTIME = "node"
+    }
+  }
+
+  assert {
+    condition     = local.merged_app_settings["FUNCTIONS_WORKER_RUNTIME"] == "node"
+    error_message = "An explicit `FUNCTIONS_WORKER_RUNTIME` in `var.app_settings` must win over the module default."
+  }
+}
+
+# Azure treats app setting names as case-insensitive, so the precedence rule
+# above has to be too. Without the `lower()` normalization in
+# `local.app_settings_keys` the module injects its own uppercase key alongside
+# the caller's, and which one Azure keeps is anybody's guess.
+run "lowercase_app_settings_entry_beats_the_module_default" {
+  command = apply
+
+  variables {
+    app_settings = {
+      functions_worker_runtime = "node"
+    }
+  }
+
+  assert {
+    condition     = local.merged_app_settings["functions_worker_runtime"] == "node"
+    error_message = "A lowercase `functions_worker_runtime` in `var.app_settings` must survive, because Azure treats app setting names as case-insensitive."
+  }
+
+  assert {
+    condition     = !contains(keys(local.merged_app_settings), "FUNCTIONS_WORKER_RUNTIME")
+    error_message = "When the caller has already set the worker runtime under any casing, the module must not also send its own `FUNCTIONS_WORKER_RUNTIME` key."
+  }
+}
+
+# `var.app_settings` is nullable, and reading the caller's keys is what makes
+# that fragile: `keys(null)` fails with an opaque argument-must-not-be-null
+# error. Hence the `coalesce()` in `local.app_settings`.
+run "null_app_settings_still_plans_and_keeps_the_default" {
+  command = apply
+
+  variables {
+    app_settings = null
+  }
+
+  assert {
+    condition     = local.merged_app_settings["FUNCTIONS_WORKER_RUNTIME"] == "dotnet"
+    error_message = "`app_settings = null` must still plan, and with no caller-supplied key the module default of `dotnet` still applies."
+  }
+}
+
+run "web_apps_do_not_get_a_worker_runtime" {
+  command = apply
+
+  variables {
+    kind = "webapp"
+  }
+
+  assert {
+    condition     = !contains(keys(local.merged_app_settings), "FUNCTIONS_WORKER_RUNTIME")
+    error_message = "Only Logic Apps should get a module-supplied `FUNCTIONS_WORKER_RUNTIME`."
+  }
+}
+
+# Function Apps carry a `FUNCTIONS_WORKER_RUNTIME` of their own in Azure, but
+# this module has never set it for them and #362 does not change that: the value
+# depends on the language stack the consumer deployed, which the module cannot
+# infer. Pinning it here so the Logic App default is not later generalized into
+# one for every Functions host.
+run "function_apps_do_not_get_a_worker_runtime" {
+  command = apply
+
+  variables {
+    kind    = "functionapp"
+    os_type = "Linux"
+  }
+
+  assert {
+    condition     = !contains(keys(local.merged_app_settings), "FUNCTIONS_WORKER_RUNTIME")
+    error_message = "The module must not invent a `FUNCTIONS_WORKER_RUNTIME` for Function Apps; the value depends on the consumer's language stack."
+  }
+}
+
+# A Function App caller who does set the runtime themselves must still see it,
+# which is the other half of "non-Logic-App kinds are unaffected".
+run "function_app_app_settings_entry_survives" {
+  command = apply
+
+  variables {
+    kind    = "functionapp"
+    os_type = "Linux"
+    app_settings = {
+      FUNCTIONS_WORKER_RUNTIME = "python"
+    }
+  }
+
+  assert {
+    condition     = local.merged_app_settings["FUNCTIONS_WORKER_RUNTIME"] == "python"
+    error_message = "A Function App caller's own `FUNCTIONS_WORKER_RUNTIME` must pass through untouched."
+  }
+}


### PR DESCRIPTION
`local.logic_app_settings` hardcoded `FUNCTIONS_WORKER_RUNTIME = "node"` for every Standard Logic App. Microsoft's [app settings reference](https://learn.microsoft.com/en-us/azure/logic-apps/edit-app-settings-host-settings#reference-for-app-settings---localsettingsjson) documents `dotnet` as the required value and describes `node` as what it used to be: "This setting's value was previously set to `node`, but now the required value is `dotnet` for all new and existing deployed Standard logic apps. This change shouldn't affect your workflow's runtime, so everything should work the same way as before."

I re-read that page against the live docs rather than taking #362's word for it, or my own earlier draft's. The table still lists the setting as Required `Yes` with a default of `dotnet`. There is no version qualifier, no runtime-version carve-out, and no migration window stated, so it applies to every Logic App this module produces.

## Override guard as well as the corrected value

The setting carried the same defect #282 reported and #344 fixed on the line directly above it. Module defaults merge *after* `var.app_settings`, so a consumer who set `FUNCTIONS_WORKER_RUNTIME` themselves had it silently discarded. I did both halves rather than only correcting the literal, because correcting the literal alone leaves `dotnet` just as un-overridable as `node` was, and the people most likely to need an override are exactly the ones this change moves off `node`.

The reason to hesitate is that this is a required setting and an override mechanism can become a way to omit it. That is a real concern for the shape #344 used, where a nullable root variable means `logic_app_node_version = null` legitimately drops `WEBSITE_NODE_DEFAULT_VERSION` entirely. I deliberately did not add a variable here. The guard is only `!contains(local.app_settings_keys, "functions_worker_runtime")`, which yields exactly when the caller has supplied a key of their own.

The case-insensitive comparison is carried over from #344 for consistency, and it is worth being precise about why, because the justification is behavioral rather than documented. I checked `configure-common`, `reference-app-settings`, and the Functions app settings reference: **none of them actually state that app setting names are compared case-insensitively.** The App Service platform is widely observed to behave that way, and #344 already committed the module to that assumption on the line above, but I could not cite it, so I am flagging it rather than restating it as documented fact. If the assumption is wrong, the failure mode is that a caller writing `functions_worker_runtime` suppresses the module's `FUNCTIONS_WORKER_RUNTIME` without actually setting the same thing.

## `azapi_update_resource` caveat

`modules/config_appsettings` manages `appsettings` with `azapi_update_resource`, which GETs the resource, merges the configured body over it, and PUTs the result. Omitting a key preserves the remote value rather than clearing it.

The main change is safe under those semantics: the module emits an explicit `FUNCTIONS_WORKER_RUNTIME = "dotnet"`, which merges over a deployed `node`. This is the "emit an explicit value" case, not the "stop emitting a key" case.

The override path is where the caveat lives. If an app was previously deployed by this module — so Azure holds `FUNCTIONS_WORKER_RUNTIME` — and the caller now pins the runtime under different casing, the module stops emitting its uppercase key while the remote value survives the merge. That app ends up carrying both keys, and `ignore_missing_property` defaults to true, so the orphan never shows as drift. The module cannot clear it. Pinning under the same uppercase spelling has no such problem. This is the #382 class of defect and is not fixed here.

## Upgrade note

Existing deployed Logic Apps move from `node` to `dotnet` on the next apply. Microsoft says this should not affect workflow runtime behavior, but it is still a change to a required runtime setting on live infrastructure, so I am calling it breaking and it wants a minor bump per SNFR17. Anyone who wants to stay on the old value can now pin it, which they could not do before this change:

```hcl
app_settings = {
  FUNCTIONS_WORKER_RUNTIME = "node"
}
```

Use that uppercase spelling, per the caveat above.

## Tests

New `tests/unit/logic_app_worker_runtime.tftest.hcl`, asserting on `local.merged_app_settings` directly rather than publishing an output that echoes the caller's input back — the pattern rejected in #344, #346, and #350.

Mutation-checked all three halves, re-run after the rebase rather than carried over from the earlier draft:

- Reverting the literal to `node` and keeping the guard fails `logic_app_defaults_to_the_documented_worker_runtime` and `null_app_settings_still_plans_and_keeps_the_default`, and nothing else.
- Replacing the guard condition with `true` fails `explicit_app_settings_entry_beats_the_module_default` and `lowercase_app_settings_entry_beats_the_module_default`, and nothing else.
- Comparing against raw `keys(local.app_settings)` instead of the lowercased list fails `lowercase_app_settings_entry_beats_the_module_default` alone, which is what pins the case-insensitive half specifically.

Full suite is 106/106 on the rebase, and 104/106 or 105/106 under each mutation above.

Candidly, the two Function App runs do not discriminate this change and passed under every mutation. They are pins, not proof: the module has never set a worker runtime for Functions hosts, correctly, because the right value depends on the language stack the consumer deployed and the module cannot see it. They exist so that this Logic App default is not later generalized into one for every Functions host.

### What the tests do not cover

`the_worker_runtime_is_always_present_on_a_logic_app` checks key presence, not that the key has a usable value. I probed the gap directly: `app_settings = { FUNCTIONS_WORKER_RUNTIME = null }` is accepted by `map(string)`, suppresses the module default, and leaves the key present with a value of `null`. So "the key is always present" is literally true but weaker than it sounds. It is a pathological input, and it is the same hole every guarded setting in the module has, including #344's — I am recording it rather than widening this PR to fix the general case.

## Validation

- `avm test unit`: 106 passed, 0 failed.
- `avm pre-commit`: all five stages pass, no generated-doc drift (this change touches no variables or outputs, so no README regeneration was needed).
- `avm pr-check`: all eight stages pass with Avm.Authoring 0.12.4.
- CI on this head is green across all 31 checks, including the `logic_app` end-to-end deployment, so Azure demonstrably accepts a Standard Logic App created with `dotnet`. No example *asserts* on the setting, though, so that is deployment evidence rather than a value check; the assertion lives in the unit runs against the `appsettings` request body.
- No local deployment.

## Not included

No new root variable, per the reasoning above. No change to `FUNCTIONS_EXTENSION_VERSION`, which #365 is handling for Flex Consumption, and no change to `WEBSITE_NODE_DEFAULT_VERSION`, which #344 already settled — #362 explicitly asked to keep this separable from the Node major-version work.

Rebased onto `main` after #376 merged; the change itself is unmodified.

Fixes #362

_Drafted by Copilot with Claude Opus 5._
