### PR TITLE
fix!: omit app settings Flex Consumption deprecates

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ Default: `null`
 
 ### <a name="input_content_share_force_disabled"></a> [content\_share\_force\_disabled](#input\_content\_share\_force\_disabled)
 
-Description: Should content share be force disabled for the Function App? Defaults to `false`.
+Description: Should content share be force disabled for the Function App? Defaults to `false`. Ignored when `function_app_uses_fc1` is `true`: Flex Consumption apps have no content share, and `WEBSITE_CONTENTSHARE` is deprecated there.
 
 Type: `bool`
 
@@ -1438,7 +1438,11 @@ Default: `false`
 
 ### <a name="input_functions_extension_version"></a> [functions\_extension\_version](#input\_functions\_extension\_version)
 
-Description: The version of the Azure Functions runtime to use. Defaults to `~4`.
+Description: The version of the Azure Functions runtime to use, set through the `FUNCTIONS_EXTENSION_VERSION` app setting. Defaults to `~4`.
+
+Ignored when `function_app_uses_fc1` is `true`. Flex Consumption deprecates `FUNCTIONS_EXTENSION_VERSION` and the backend sets the value itself, so the module does not send it.
+
+If you set both this variable and `FUNCTIONS_EXTENSION_VERSION` in `var.app_settings`, the `var.app_settings` entry wins, under any casing — Azure treats app setting names as case-insensitive. That is also how you pin the setting on a Flex Consumption app despite the gate above. (Function App)
 
 Type: `string`
 

--- a/README.md
+++ b/README.md
@@ -1440,7 +1440,7 @@ Default: `false`
 
 Description: The version of the Azure Functions runtime to use, set through the `FUNCTIONS_EXTENSION_VERSION` app setting. Defaults to `~4`.
 
-Ignored when `function_app_uses_fc1` is `true`. Flex Consumption deprecates `FUNCTIONS_EXTENSION_VERSION` and the backend sets the value itself, so the module does not send it.
+Ignored when `function_app_uses_fc1` is `true`. Flex Consumption deprecates `FUNCTIONS_EXTENSION_VERSION` and the backend sets the value itself, so the module stops volunteering it. That governs what the module writes: an app that already carries the setting keeps its existing value, which Flex Consumption ignores regardless.
 
 If you set both this variable and `FUNCTIONS_EXTENSION_VERSION` in `var.app_settings`, the `var.app_settings` entry wins, under any casing — Azure treats app setting names as case-insensitive. That is also how you pin the setting on a Flex Consumption app despite the gate above. (Function App)
 

--- a/locals.app_settings.tf
+++ b/locals.app_settings.tf
@@ -20,10 +20,43 @@ locals {
     var.site_config.application_insights_key,
     var.application_insights_key,
   ), null)
+  # Flex Consumption (FC1) deprecates a list of app settings, and two of them are
+  # ones this module emits for Function Apps: FUNCTIONS_EXTENSION_VERSION and
+  # WEBSITE_CONTENTSHARE. Both are gated on var.function_app_uses_fc1 below. See
+  # "Flex Consumption plan deprecations" in the Functions app settings reference.
+  #
+  # These are *deprecated*, not rejected — the distinction matters, and it is the
+  # opposite of the siteConfig properties #345 suppressed. Those come back as a
+  # hard ARM 51021 error. These do not: the table records
+  # FUNCTIONS_EXTENSION_VERSION as "App Setting is set by the backend", and FC1
+  # has no content share for WEBSITE_CONTENTSHARE to name. An FC1 deployment
+  # carrying either one succeeds today and always has; the values are simply
+  # overwritten or ignored. Omitting them stops the module from asserting
+  # configuration it does not control, rather than fixing a failing deployment.
+  #
+  # Omitting is also the whole of it. modules/config_appsettings writes through
+  # azapi_update_resource, which merges the configured body over what Azure
+  # already has, so dropping a key stops the module volunteering it and leaves
+  # any previously written value live on an existing app. The gate therefore
+  # takes effect for new deployments; upgraded FC1 apps keep the setting they
+  # already had, which FC1 ignores anyway. That limitation is module-wide and
+  # tracked in #382 — do not try to solve it here.
+  #
+  # The rest of what this module sends is not on that list. AzureWebJobsStorage
+  # and its `__accountName` sibling are the *host* storage connection, which FC1
+  # still requires and which the table does not name; only the deployment-storage
+  # settings were replaced. AzureWebJobsFeatureFlags, AzureWebJobsDashboard and
+  # APPINSIGHTS_INSTRUMENTATIONKEY are absent from the table too. See #365.
   function_app_settings = local.is_function_app ? merge(
-    {
+    # Carries the same case-insensitive override guard #344 introduced for
+    # WEBSITE_NODE_DEFAULT_VERSION, for the same reason: module defaults are
+    # merged *after* var.app_settings, so without it a caller who sets this key
+    # directly has it silently overwritten by var.functions_extension_version.
+    # The guard doubles as the escape hatch from the FC1 gate above — an FC1
+    # caller who really does want to pin the value can still set it explicitly.
+    !var.function_app_uses_fc1 && !contains(local.app_settings_keys, "functions_extension_version") ? {
       FUNCTIONS_EXTENSION_VERSION = var.functions_extension_version
-    },
+    } : {},
     # An identity-based host storage connection *replaces* the connection string
     # rather than sitting beside it: `AzureWebJobsStorage__accountName` "sets the
     # account name of the storage account instead of using the connection string
@@ -82,7 +115,8 @@ locals {
       AzureWebJobsFeatureFlags = "EnableWorkerIndexing"
       AzureWebJobsDashboard    = ""
     },
-    var.content_share_force_disabled ? {
+    # No-op on FC1, where there is no content share to disable.
+    var.content_share_force_disabled && !var.function_app_uses_fc1 ? {
       WEBSITE_CONTENTSHARE = ""
     } : {},
   ) : {}

--- a/tests/unit/fc1_app_settings.tftest.hcl
+++ b/tests/unit/fc1_app_settings.tftest.hcl
@@ -1,0 +1,216 @@
+// `local.merged_app_settings` is the map the module hands
+// `modules/config_appsettings` as its request body, so asserting on it covers
+// the behavior these runs care about without publishing an output that just
+// echoes the caller's own input back (TFFR2). This matches how
+// `tests/unit/logic_app_node_version.tftest.hcl` asserts on the same local.
+//
+// Flex Consumption *deprecates* these settings rather than rejecting them, so
+// unlike the siteConfig properties in `tests/unit/fc1_site_config.tftest.hcl`
+// there is no ARM error to reproduce and an e2e deployment can never fail on
+// them. Plan-time assertions are the only signal available. See issue #365.
+
+mock_provider "azapi" {
+  # Downstream submodules validate that parent_id looks like a real site
+  # resource ID, so the default random mock ID has to be overridden.
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-avm-test/providers/Microsoft.Web/sites/func-avm-test"
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {}
+mock_provider "time" {}
+
+variables {
+  enable_telemetry         = false
+  kind                     = "functionapp"
+  location                 = "eastus"
+  name                     = "func-avm-test"
+  os_type                  = "Linux"
+  parent_id                = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-avm-test"
+  service_plan_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-avm-test/providers/Microsoft.Web/serverfarms/asp-avm-test"
+}
+
+run "fc1_omits_the_deprecated_app_settings" {
+  command = apply
+
+  variables {
+    content_share_force_disabled = true
+    fc1_runtime_name             = "node"
+    fc1_runtime_version          = "20"
+    function_app_uses_fc1        = true
+    storage_authentication_type  = "SystemAssignedIdentity"
+    storage_container_endpoint   = "https://stavmtest.blob.core.windows.net/deployments"
+    storage_container_type       = "blobContainer"
+  }
+
+  assert {
+    condition     = !contains(keys(local.merged_app_settings), "FUNCTIONS_EXTENSION_VERSION")
+    error_message = "Flex Consumption deprecates `FUNCTIONS_EXTENSION_VERSION` and sets it from the backend, so the module must not send it."
+  }
+  assert {
+    condition     = !contains(keys(local.merged_app_settings), "WEBSITE_CONTENTSHARE")
+    error_message = "Flex Consumption has no content share, so `content_share_force_disabled` must not produce a `WEBSITE_CONTENTSHARE` key."
+  }
+}
+
+# The gate is only defensible if it is narrow: everything else the module sends
+# for a Function App is absent from the Flex Consumption deprecation table and
+# must survive.
+run "fc1_still_sends_the_settings_that_are_not_deprecated" {
+  command = apply
+
+  variables {
+    builtin_logging_enabled     = false
+    fc1_runtime_name            = "node"
+    fc1_runtime_version         = "20"
+    function_app_uses_fc1       = true
+    storage_authentication_type = "SystemAssignedIdentity"
+    storage_container_endpoint  = "https://stavmtest.blob.core.windows.net/deployments"
+    storage_container_type      = "blobContainer"
+  }
+
+  assert {
+    condition     = local.merged_app_settings["AzureWebJobsFeatureFlags"] == "EnableWorkerIndexing"
+    error_message = "`AzureWebJobsFeatureFlags` is not on the Flex Consumption deprecation list and must still be sent."
+  }
+  assert {
+    condition     = contains(keys(local.merged_app_settings), "AzureWebJobsDashboard")
+    error_message = "`AzureWebJobsDashboard` is not on the Flex Consumption deprecation list and must still be sent."
+  }
+}
+
+run "non_fc1_still_sends_the_extension_version" {
+  command = apply
+
+  variables {
+    content_share_force_disabled = true
+    function_app_uses_fc1        = false
+  }
+
+  assert {
+    condition     = local.merged_app_settings["FUNCTIONS_EXTENSION_VERSION"] == "~4"
+    error_message = "A non-Flex Consumption Function App must still get `FUNCTIONS_EXTENSION_VERSION`, defaulting to `~4`."
+  }
+  assert {
+    condition     = local.merged_app_settings["WEBSITE_CONTENTSHARE"] == ""
+    error_message = "`content_share_force_disabled` must still empty `WEBSITE_CONTENTSHARE` outside Flex Consumption."
+  }
+}
+
+run "non_fc1_extension_version_is_configurable" {
+  command = apply
+
+  variables {
+    functions_extension_version = "~3"
+  }
+
+  assert {
+    condition     = local.merged_app_settings["FUNCTIONS_EXTENSION_VERSION"] == "~3"
+    error_message = "Setting `functions_extension_version` should change the `FUNCTIONS_EXTENSION_VERSION` app setting."
+  }
+}
+
+# The module merges its Function App defaults after `var.app_settings`, so
+# without an explicit gate it silently overwrites whatever the consumer set
+# here. This is the same shape #344 fixed for WEBSITE_NODE_DEFAULT_VERSION.
+#
+# This run, `app_settings_wins_when_both_inputs_are_set` and
+# `lowercase_app_settings_entry_beats_the_module_default` are the discriminating
+# set for the `!contains(local.app_settings_keys, ...)` clause: strip it and
+# those three alone fail, while the rest still pass.
+run "explicit_app_settings_entry_beats_the_module_default" {
+  command = apply
+
+  variables {
+    app_settings = {
+      FUNCTIONS_EXTENSION_VERSION = "~3"
+    }
+  }
+
+  assert {
+    condition     = local.merged_app_settings["FUNCTIONS_EXTENSION_VERSION"] == "~3"
+    error_message = "An explicit `FUNCTIONS_EXTENSION_VERSION` in `var.app_settings` must win over the module's `functions_extension_version` default."
+  }
+}
+
+# The run above leaves `functions_extension_version` at its default, so it only
+# proves `var.app_settings` beats the *default*. This one sets both inputs
+# explicitly to different values, which pins the documented precedence rule
+# itself rather than a property of the default value.
+run "app_settings_wins_when_both_inputs_are_set" {
+  command = apply
+
+  variables {
+    functions_extension_version = "~4"
+    app_settings = {
+      FUNCTIONS_EXTENSION_VERSION = "~3"
+    }
+  }
+
+  assert {
+    condition     = local.merged_app_settings["FUNCTIONS_EXTENSION_VERSION"] == "~3"
+    error_message = "When both `functions_extension_version` and `app_settings.FUNCTIONS_EXTENSION_VERSION` are set, the `app_settings` entry must win."
+  }
+}
+
+# Azure treats app setting names as case-insensitive, so the precedence rule
+# above has to be too. Without the `lower()` normalization in
+# `local.app_settings_keys` the module injects its own uppercase key alongside
+# the caller's, and which one Azure keeps is anybody's guess.
+run "lowercase_app_settings_entry_beats_the_module_default" {
+  command = apply
+
+  variables {
+    app_settings = {
+      functions_extension_version = "~3"
+    }
+  }
+
+  assert {
+    condition     = local.merged_app_settings["functions_extension_version"] == "~3"
+    error_message = "A lowercase `functions_extension_version` in `var.app_settings` must survive, because Azure treats app setting names as case-insensitive."
+  }
+  assert {
+    condition     = !contains(keys(local.merged_app_settings), "FUNCTIONS_EXTENSION_VERSION")
+    error_message = "When the caller has already set the extension version under any casing, the module must not also send its own `FUNCTIONS_EXTENSION_VERSION` key."
+  }
+}
+
+# The override guard is what keeps the Flex Consumption gate from being a wall.
+# A caller who has a reason to pin the value on FC1 can still say so directly,
+# and the module must not second-guess that.
+run "fc1_keeps_an_explicit_app_settings_entry" {
+  command = apply
+
+  variables {
+    fc1_runtime_name            = "node"
+    fc1_runtime_version         = "20"
+    function_app_uses_fc1       = true
+    storage_authentication_type = "SystemAssignedIdentity"
+    storage_container_endpoint  = "https://stavmtest.blob.core.windows.net/deployments"
+    storage_container_type      = "blobContainer"
+    app_settings = {
+      FUNCTIONS_EXTENSION_VERSION = "~4"
+    }
+  }
+
+  assert {
+    condition     = local.merged_app_settings["FUNCTIONS_EXTENSION_VERSION"] == "~4"
+    error_message = "Gating the module default must not strip a `FUNCTIONS_EXTENSION_VERSION` the caller set explicitly through `var.app_settings`."
+  }
+}
+
+run "non_function_app_kinds_do_not_get_an_extension_version" {
+  command = apply
+
+  variables {
+    kind = "webapp"
+  }
+
+  assert {
+    condition     = !contains(keys(local.merged_app_settings), "FUNCTIONS_EXTENSION_VERSION")
+    error_message = "Only Function Apps should get a module-supplied `FUNCTIONS_EXTENSION_VERSION`."
+  }
+}

--- a/tests/unit/fc1_app_settings.tftest.hcl
+++ b/tests/unit/fc1_app_settings.tftest.hcl
@@ -116,10 +116,11 @@ run "non_fc1_extension_version_is_configurable" {
 # without an explicit gate it silently overwrites whatever the consumer set
 # here. This is the same shape #344 fixed for WEBSITE_NODE_DEFAULT_VERSION.
 #
-# This run, `app_settings_wins_when_both_inputs_are_set` and
-# `lowercase_app_settings_entry_beats_the_module_default` are the discriminating
-# set for the `!contains(local.app_settings_keys, ...)` clause: strip it and
-# those three alone fail, while the rest still pass.
+# This run, `app_settings_wins_when_both_inputs_are_set`,
+# `lowercase_app_settings_entry_beats_the_module_default` and
+# `an_explicit_null_app_settings_entry_still_suppresses_the_default` are the
+# discriminating set for the `!contains(local.app_settings_keys, ...)` clause:
+# strip it and those four alone fail, while the rest still pass.
 run "explicit_app_settings_entry_beats_the_module_default" {
   command = apply
 
@@ -199,6 +200,27 @@ run "fc1_keeps_an_explicit_app_settings_entry" {
   assert {
     condition     = local.merged_app_settings["FUNCTIONS_EXTENSION_VERSION"] == "~4"
     error_message = "Gating the module default must not strip a `FUNCTIONS_EXTENSION_VERSION` the caller set explicitly through `var.app_settings`."
+  }
+}
+
+# A caller who writes the key with an explicit `null` has still *set* it, so the
+# guard yields and the module's own value stays out. The entry survives into the
+# request body as a JSON null rather than disappearing, which is the behavior
+# #384 settled on for the module generally; whether Azure then clears the setting
+# or ignores the null is the open question in #382, and nothing here can answer
+# it.
+run "an_explicit_null_app_settings_entry_still_suppresses_the_default" {
+  command = apply
+
+  variables {
+    app_settings = {
+      FUNCTIONS_EXTENSION_VERSION = null
+    }
+  }
+
+  assert {
+    condition     = local.merged_app_settings["FUNCTIONS_EXTENSION_VERSION"] == null
+    error_message = "An explicit `null` is a caller-set key, so the module must not overwrite it with `functions_extension_version`."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1284,7 +1284,7 @@ variable "functions_extension_version" {
   description = <<DESCRIPTION
 The version of the Azure Functions runtime to use, set through the `FUNCTIONS_EXTENSION_VERSION` app setting. Defaults to `~4`.
 
-Ignored when `function_app_uses_fc1` is `true`. Flex Consumption deprecates `FUNCTIONS_EXTENSION_VERSION` and the backend sets the value itself, so the module does not send it.
+Ignored when `function_app_uses_fc1` is `true`. Flex Consumption deprecates `FUNCTIONS_EXTENSION_VERSION` and the backend sets the value itself, so the module stops volunteering it. That governs what the module writes: an app that already carries the setting keeps its existing value, which Flex Consumption ignores regardless.
 
 If you set both this variable and `FUNCTIONS_EXTENSION_VERSION` in `var.app_settings`, the `var.app_settings` entry wins, under any casing — Azure treats app setting names as case-insensitive. That is also how you pin the setting on a Flex Consumption app despite the gate above. (Function App)
 DESCRIPTION

--- a/variables.tf
+++ b/variables.tf
@@ -528,7 +528,7 @@ variable "container_size" {
 variable "content_share_force_disabled" {
   type        = bool
   default     = false
-  description = "Should content share be force disabled for the Function App? Defaults to `false`."
+  description = "Should content share be force disabled for the Function App? Defaults to `false`. Ignored when `function_app_uses_fc1` is `true`: Flex Consumption apps have no content share, and `WEBSITE_CONTENTSHARE` is deprecated there."
 }
 
 variable "custom_domains" {
@@ -1281,7 +1281,13 @@ DESCRIPTION
 variable "functions_extension_version" {
   type        = string
   default     = "~4"
-  description = "The version of the Azure Functions runtime to use. Defaults to `~4`."
+  description = <<DESCRIPTION
+The version of the Azure Functions runtime to use, set through the `FUNCTIONS_EXTENSION_VERSION` app setting. Defaults to `~4`.
+
+Ignored when `function_app_uses_fc1` is `true`. Flex Consumption deprecates `FUNCTIONS_EXTENSION_VERSION` and the backend sets the value itself, so the module does not send it.
+
+If you set both this variable and `FUNCTIONS_EXTENSION_VERSION` in `var.app_settings`, the `var.app_settings` entry wins, under any casing — Azure treats app setting names as case-insensitive. That is also how you pin the setting on a Flex Consumption app despite the gate above. (Function App)
+DESCRIPTION
 }
 
 variable "host_names_disabled" {


### PR DESCRIPTION
`FUNCTIONS_EXTENSION_VERSION` is on Microsoft's [Flex Consumption plan deprecations](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#flex-consumption-plan-deprecations) list, and `locals.app_settings.tf` set it unconditionally for every Function App. This gates it, and the one other setting on that list the Function App branch emits, behind `!var.function_app_uses_fc1`.

Worth being precise about the failure mode, because it is not the one #345 dealt with. Those `siteConfig` properties are *rejected*: ARM returns a hard 51021 error and the deployment dies. These app settings are only *deprecated*. The reason the table gives for `FUNCTIONS_EXTENSION_VERSION` is "App Setting is set by the backend. A value of ~1 can be ignored" — FC1 ignores what we send and sets its own. Our `flex_consumption` example passes `function_app_uses_fc1 = true` and has been deploying with this setting all along, so nothing is failing today and nothing has been. What we are fixing is the module asserting configuration it does not control, and handing FC1 users a setting that reads as meaningful and isn't.

## What the gate does, and what it does not

It stops the module volunteering these two settings. It does not remove them from an app that already has them.

`modules/config_appsettings` writes through `azapi_update_resource`, which GETs the existing resource, merges the configured `body` over it, and PUTs the result. A key absent from `body` keeps whatever Azure already had, and `ignore_missing_property` defaults to `true` — I re-checked both against the provider's current documentation rather than trusting the note I wrote last time. So the gate takes effect for **new deployments**; an existing FC1 app that upgrades keeps the value previously written, which is exactly the state it is in today and which FC1 ignores regardless.

That is not a property of this change — it is a property of the resource type every config submodule in this repo is built on, and it is tracked module-wide in #382. Fixing it means moving to `azapi_resource` with `moved` blocks and a state migration, which is that issue's job and deliberately not attempted here.

**The tests below cannot close that gap, and I want that said plainly.** They assert on `local.merged_app_settings`, which is the request body — the layer *before* the provider's merge. Nothing here is evidence about what Azure does to an app that already carries these settings, and I have not deployed one to find out.

## What else is on that list

I checked the whole table against every app setting this module emits, since fixing only the one the issue named would leave the same bug next door.

In the Function App branch, `WEBSITE_CONTENTSHARE` is the only other hit, so it is gated the same way. That makes `content_share_force_disabled` a no-op on FC1, which is the honest outcome: FC1 has no content share, so there is nothing there to force off. The table says it is "replaced by functionAppConfig's deployment section", which the module already populates from `storage_container_endpoint`.

Deliberately left alone:

- `AzureWebJobsStorage` and the `AzureWebJobsStorage__accountName`/`__credential`/`__clientId` trio #376 landed are the *host* storage connection, which FC1 still requires. Only the deployment-storage settings (`WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`, `WEBSITE_CONTENTSHARE`) were replaced, and the table names those two specifically while saying nothing about `AzureWebJobsStorage`.
- `AzureWebJobsFeatureFlags` and `AzureWebJobsDashboard` are absent from the table. `AzureWebJobsDashboard` is deprecated in the general sense — it only ever applied to runtime v1.x — but that is a different axis from Flex Consumption, and we emit it as `""`, which is the idiom for switching it off. Not this PR's problem.
- `APPINSIGHTS_INSTRUMENTATIONKEY` is likewise absent from the table. It is discouraged in favour of `APPLICATIONINSIGHTS_CONNECTION_STRING` everywhere, not just on FC1, and it is only emitted when a caller supplies a key.
- The Logic App branch emits `FUNCTIONS_EXTENSION_VERSION`, `FUNCTIONS_WORKER_RUNTIME`, `WEBSITE_CONTENTSHARE` and `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`, all four on the table. Standard logic apps run on a Workflow Service Plan, ASEv3 or Hybrid — [Flex Consumption is not one of the hosting options](https://learn.microsoft.com/en-us/azure/logic-apps/single-tenant-overview-compare) — so none of it applies. `kind` also makes `local.is_function_app` and `local.is_logic_app` mutually exclusive, so this gate cannot reach that branch even by accident.

## The override guard

`FUNCTIONS_EXTENSION_VERSION` picks up the case-insensitive override guard #344 introduced for `WEBSITE_NODE_DEFAULT_VERSION`. It is the identical shape: module defaults merge *after* `var.app_settings`, so a caller who set the key directly had their value silently overwritten by `var.functions_extension_version`. Without the guard the module would carry two different precedence rules for two settings of exactly the same kind.

It also earns its place here specifically. The gate is the module declining to volunteer a value, not the module forbidding one, and the guard is what makes that true — an FC1 caller with a reason to pin the setting can still say so through `app_settings` and we pass it through untouched. `fc1_keeps_an_explicit_app_settings_entry` pins that.

An explicit `null` counts as the caller having set the key: `keys()` still sees it, the guard yields, and the entry reaches the request body as a JSON null rather than vanishing — which is the behaviour #384 settled on for the module generally. Whether Azure reads that null as "clear the setting" is the open question in #382, and I have not answered it. `an_explicit_null_app_settings_entry_still_suppresses_the_default` pins the half that is ours.

## Rebased onto current `main`

This branch was originally cut on top of #377, which #384 has since reverted, so it needed rebasing rather than merging. It now sits directly on `main` at cac294d35, which is the squash of #379.

The one conflict was against #376, not #379: #376 had rewritten the `AzureWebJobsStorage` block that the extension-version gate sits above. I kept #376's block verbatim and reapplied only the gate. The whole functional delta against `main` is now three lines — the two gate conditions and the `} : {}` that closes the first one; everything else in the file diff is comments.

Because a clean rebase is not by itself evidence that the neighbouring behaviour survived, I reverted each neighbour on the combined tree to confirm its tests still bite here:

- Putting #379's `FUNCTIONS_WORKER_RUNTIME` back to `"node"` fails 2 runs in `tests/unit/logic_app_worker_runtime.tftest.hcl`.
- Removing #376's `AzureWebJobsStorage__credential` key fails `tests/unit/identity_based_host_storage.tftest.hcl`.

Both files run green unmodified, 26 runs between them.

## Upgrade note

Both gates change the body the module sends, so this is a behaviour change rather than a pure bug fix, and pre-1.0 that means the next release is a **minor** bump — [SNFR17](https://azure.github.io/Azure-Verified-Modules/spec/SNFR17) with [SNFR18](https://azure.github.io/Azure-Verified-Modules/spec/SNFR18), which puts features and breaking changes alike in minor while major is frozen. `v0.22.0` is current; I am not claiming which release this ships in, since several PRs are in flight. The title is `fix!:` so the squash commit carries the classification, matching #344.

In practice nobody should notice. New FC1 deployments simply stop receiving two settings the platform was overwriting or ignoring anyway; existing FC1 apps keep what was already written, per the caveat above, and are no worse off than before. The one visible effect is on a non-FC1 app where a caller set both `var.functions_extension_version` and `app_settings.FUNCTIONS_EXTENSION_VERSION` to different values — the `app_settings` entry now wins where the variable used to. That is already the documented rule for `logic_app_node_version`.

## Testing

`tests/unit/fc1_app_settings.tftest.hcl` asserts on `local.merged_app_settings` directly, the same way `tests/unit/logic_app_node_version.tftest.hcl` does, rather than publishing an output that just echoes the caller's own input back (TFFR2). There is no e2e signal available for any of this: FC1 accepts these settings, so a deployment can never fail on them, which is the inverse of the region-dependent 51021 problem that made `tests/unit/fc1_site_config.tftest.hcl` necessary. Plan-time assertions are all there is.

Mutation results, all measured against the head that ships:

| Mutation | Result |
| --- | --- |
| Drop `!var.function_app_uses_fc1` from the extension version | `fc1_omits_the_deprecated_app_settings` fails, and nothing else |
| Drop it from `WEBSITE_CONTENTSHARE` | The same run fails, on its other assertion |
| Drop the `!contains(local.app_settings_keys, ...)` clause | Exactly the four runs the comment in that file names fail; the other 112 pass |
| Invert both gates | `fc1_omits_the_deprecated_app_settings` and `non_fc1_still_sends_the_extension_version` fail — the over-suppression case |
| Revert #379's `dotnet` worker runtime to `node` | 2 runs in `logic_app_worker_runtime.tftest.hcl` fail |
| Remove #376's `AzureWebJobsStorage__credential` | `identity_based_host_storage.tftest.hcl` fails |

`avm test unit` (116 runs, 116 passed), `avm pre-commit` (clean, no generated-doc drift) and a clean-worktree `avm pr-check` (8/8 steps) all pass. The two lint warnings about deprecated `lock` and `role_assignments` interface variants are pre-existing on `main`.

Fixes #365

_Drafted by Copilot with Claude Opus 5._