### PR TITLE
fix: track the AVM ruleset's renamed lint rules

### DIFF
--- a/avm.tflint.override.hcl
+++ b/avm.tflint.override.hcl
@@ -1,7 +1,7 @@
-rule "diagnostic_settings" {
+rule "avm_interface_diagnostic_settings" {
   enabled = false
 }
 
-rule "private_endpoints" {
+rule "avm_interface_private_endpoints" {
   enabled = false
 }

--- a/avm.tflint_module.override.hcl
+++ b/avm.tflint_module.override.hcl
@@ -1,11 +1,11 @@
-rule "required_output_rmfr7" {
+rule "avm_output_resource_id_required" {
   enabled = false
 }
 
-rule "required_module_source_tffr1" {
+rule "avm_terraform_module_source_required" {
   enabled = false
 }
 
-rule "private_endpoints" {
+rule "avm_interface_private_endpoints" {
   enabled = false
 }

--- a/examples/zip_deploy_file/avm.tflint.override.hcl
+++ b/examples/zip_deploy_file/avm.tflint.override.hcl
@@ -1,3 +1,3 @@
-rule "provider_azurerm_disallowed" {
+rule "avm_provider_azurerm_disallowed" {
   enabled = false
 }

--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -87,7 +87,7 @@ resource "azapi_resource" "private_endpoint" {
   response_export_values = []
   retry                  = var.retry
   # Private endpoint tags are defined per endpoint by the AVM interface.
-  # tflint-ignore: azapi_resource_tag
+  # tflint-ignore: avm_azapi_resource_tags_required
   tags           = each.value.tags
   update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 

--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -86,7 +86,9 @@ resource "azapi_resource" "private_endpoint" {
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
   retry                  = var.retry
-  # Private endpoint tags are defined per endpoint by the AVM interface.
+  # TFFR9 requires var.tags, but the canonical private endpoint interface exposes
+  # per-endpoint tags here. Remove this exception when Azure-Verified-Modules#2899
+  # defines the compliant composition.
   # tflint-ignore: avm_azapi_resource_tags_required
   tags           = each.value.tags
   update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null

--- a/main.tf
+++ b/main.tf
@@ -40,10 +40,4 @@ resource "azapi_resource" "this" {
       update = timeouts.value.update
     }
   }
-
-  lifecycle {
-    ignore_changes = [
-      tags,
-    ]
-  }
 }

--- a/modules/slot/main.interfaces.tf
+++ b/modules/slot/main.interfaces.tf
@@ -80,7 +80,7 @@ resource "azapi_resource" "private_endpoint" {
   response_export_values = []
   retry                  = var.retry
   # Private endpoint tags are defined per endpoint by the AVM interface.
-  # tflint-ignore: azapi_resource_tag
+  # tflint-ignore: avm_azapi_resource_tags_required
   tags = each.value.tags
 
   dynamic "timeouts" {

--- a/modules/slot/main.interfaces.tf
+++ b/modules/slot/main.interfaces.tf
@@ -79,7 +79,9 @@ resource "azapi_resource" "private_endpoint" {
   ignore_body_changes    = length(var.ignore_body_changes.network_private_endpoints) > 0 ? var.ignore_body_changes.network_private_endpoints : null
   response_export_values = []
   retry                  = var.retry
-  # Private endpoint tags are defined per endpoint by the AVM interface.
+  # TFFR9 requires var.tags, but the canonical private endpoint interface exposes
+  # per-endpoint tags here. Remove this exception when Azure-Verified-Modules#2899
+  # defines the compliant composition.
   # tflint-ignore: avm_azapi_resource_tags_required
   tags = each.value.tags
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -64,7 +64,7 @@ output "private_endpoints" {
 output "resource" {
   description = "This is the full output for the resource."
   sensitive   = true
-  # tflint-ignore: no_entire_resource_output_tffr2
+  # tflint-ignore: avm_output_entire_resource_disallowed
   value = azapi_resource.this
 }
 

--- a/tests/unit/tags.tftest.hcl
+++ b/tests/unit/tags.tftest.hcl
@@ -1,0 +1,48 @@
+mock_provider "azapi" {
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg/providers/Microsoft.Web/sites/unit-test-site"
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {}
+mock_provider "time" {}
+
+variables {
+  enable_telemetry         = false
+  location                 = "eastus"
+  name                     = "unit-test-site"
+  parent_id                = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg"
+  service_plan_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/unit-test-rg/providers/Microsoft.Web/serverfarms/unit-test-plan"
+}
+
+run "create_with_initial_tags" {
+  command = apply
+
+  variables {
+    tags = {
+      environment = "initial"
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this.tags["environment"] == "initial"
+    error_message = "The site should be created with the configured tags."
+  }
+}
+
+run "tag_changes_are_planned" {
+  command = plan
+
+  variables {
+    tags = {
+      environment = "updated"
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this.tags["environment"] == "updated"
+    error_message = "Changing tags must produce a planned update instead of retaining the prior state."
+  }
+}


### PR DESCRIPTION
Every PR in the repository was failing on `Failed to check rule config; Rule not found: diagnostic_settings`. The AVM TFLint ruleset renamed its rules under an `avm_` prefix: runs before 17:44 UTC passed and everything after failed, including branches that had not changed. TFLint refuses to load a config naming a rule it does not have, so lint stopped before evaluating any source.

None of that came from the open feature PRs. `main` reproduced it unmodified, and managed-files 1.0.27 does not touch these files, so the override names belong to this repository rather than an upstream sync.

## Renamed rules

The rules were renamed, not withdrawn. Removing each stale exclusion let lint report the same check under its new name:

| Old | New |
| --- | --- |
| `diagnostic_settings` | `avm_interface_diagnostic_settings` |
| `private_endpoints` | `avm_interface_private_endpoints` |
| `required_output_rmfr7` | `avm_output_resource_id_required` |
| `required_module_source_tffr1` | `avm_terraform_module_source_required` |
| `provider_azurerm_disallowed` | `avm_provider_azurerm_disallowed` |
| `azapi_resource_tag` | `avm_azapi_resource_tags_required` |
| `no_entire_resource_output_tffr2` | `avm_output_entire_resource_disallowed` |

The last two are inline suppressions rather than override files. An override naming a missing rule fails loudly; an inline suppression naming a missing rule silently stops suppressing anything.

The two private-endpoint tag suppressions expose a contract conflict rather than a clean permanent exception. The canonical private-endpoint interface exposes `private_endpoints[*].tags`, and the utility module returns that value as `each.value.tags`; TFFR9 and the rule now deliberately require exactly `tags = var.tags`. Changing the assignment would discard endpoint-specific configuration, while moving the exception into a scope override would disable tag validation for unrelated resources. Azure/Azure-Verified-Modules#2899 tracks the AVM decision needed to remove these line suppressions. Auto-merge is paused pending that direction.

The whole-resource output suppression also remains intentional. `polymind-inc/terraform-azurerm-acmebot` pins `~> 0.22.0` and consumes the provider-backed `resource` output, so removing it here would be an unrelated compatibility break.

## Tag reconciliation

The audit uncovered a separate tag defect in the same area. The root site assigned `tags = var.tags` and then used `lifecycle.ignore_changes = [tags]`, so tags were accepted on create but every later tag change was silently ignored. That lifecycle exception predates the current work and has no valid compatibility case.

This removes the exception and adds a stateful Terraform test that creates the site with one tag value, then plans a different value against the same test state. With `ignore_changes` restored, the update assertion fails; without it, the planned tags match the caller's updated configuration.

## Validation

- `avm test unit`: 77 passed, 0 failed.
- Tag negative control: the update run fails with the old lifecycle exception restored.
- `avm lint`: passes, with only the four pre-existing deprecated-interface warnings.
- `avm pre-commit`: passes with no generated-file drift.
- `avm pr-check`: passes all eight stages.
- Independent cross-family review: no significant findings.

This unblocks #376, #379, #380, #381 and #384. The managed-files 1.0.26 to 1.0.27 upgrade remains deliberately excluded; it only rewrites issue-triage workflow files and belongs in its own PR.

_Drafted by Copilot with GPT-5.6 Sol._

