### PR TITLE
fix: scope the generated helper provider exception

### DIFF
--- a/modules/site_config_helpers/avm.tflint.override.hcl
+++ b/modules/site_config_helpers/avm.tflint.override.hcl
@@ -1,0 +1,6 @@
+# Avm.Authoring currently requires AzAPI in this provider-free helper while
+# TFLint rejects the generated declaration as unused. Remove this override when
+# Azure/azure-verified-modules-tools#104 is resolved.
+rule "terraform_unused_required_providers" {
+  enabled = false
+}


### PR DESCRIPTION
Avm.Authoring 0.12.x now adds an AzAPI requirement to every local submodule through its MAPOTF `module` profile. That leaves `modules/site_config_helpers` in a deadlock: it directly uses no provider, so TFLint rejects the generated AzAPI declaration as unused; removing the declaration makes the authoring transform add it back.

This does not disable provider validation repository-wide. It suppresses `terraform_unused_required_providers` only inside `site_config_helpers`, which is the one generated configuration caught between those two rules. Root and every other submodule keep the standard lint rule.

The authoring behavior, TFNFR26 conflict, provider-floor mismatch, and full reproduction are tracked in Azure/azure-verified-modules-tools#104. The comment in the override names that issue as the removal condition; this file should disappear when authoring and lint agree again.

## Why merge this now

Every feature branch based on current `main` fails `avm pr-check` before its own changes are evaluated. This narrow exception restores a passing repository baseline without mixing an authoring-tools workaround into #376 or weakening unrelated checks.

## Validation

- `avm pre-commit`: passed.
- `avm test unit`: 80 passed, 0 failed.
- `avm pr-check`: all eight stages passed.
- Independent adversarial review: no significant findings.

_Drafted by Copilot with GPT-5.6 Sol._
