### PR TITLE
fix: remove the unused helper provider requirement

### DIFF
--- a/modules/site_config_helpers/README.md
+++ b/modules/site_config_helpers/README.md
@@ -13,8 +13,6 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
-
 ## Resources
 
 No resources.

--- a/modules/site_config_helpers/terraform.tf
+++ b/modules/site_config_helpers/terraform.tf
@@ -1,10 +1,3 @@
 terraform {
   required_version = "~> 1.9"
-
-  required_providers {
-    azapi = {
-      source  = "Azure/azapi"
-      version = "~> 2.4"
-    }
-  }
 }


### PR DESCRIPTION
Avm.Authoring 0.12.0 accidentally forced an AzAPI requirement into every local submodule, including `site_config_helpers`, which contains only variables, locals, and outputs. That left the repository unable to satisfy both gates: the transform recreated the declaration when removed, while TFLint rejected it as unused when present.

The authoring bug is fixed in Azure/azure-verified-modules-tools#105 and released in Avm.Authoring 0.12.2 and later. With the fixed transform, this module can return to its intended provider-free contract: remove the stale AzAPI requirement and regenerate the helper README.

## Plain-language summary

This helper only rearranges Terraform values; it does not call Azure. The old authoring tool nevertheless added an Azure provider to it, and lint correctly complained. The upstream tool no longer adds that provider, so this PR removes the leftover declaration instead of hiding the warning.

## Validation

- Avm.Authoring 0.12.4 / MAPOTF 0.1.12.
- `avm pre-commit`: passed; the provider was not restored.
- `avm test unit`: passed.
- `avm pr-check`: all eight stages passed.
- No TFLint override is added or disabled.

Closes the repository side of Azure/azure-verified-modules-tools#104.

_Drafted by Copilot with GPT-5.6 Sol._
